### PR TITLE
Fix CI coverage action and add README with coverage badge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,28 @@ jobs:
       run: ./scripts/combine-coverage.sh
 
     - name: Coverage comment
+      if: github.event_name == 'pull_request'
       uses: py-cov-action/python-coverage-comment-action@v3
       with:
         GITHUB_TOKEN: ${{ github.token }}
+
+    - name: Get coverage percentage for badge
+      if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+      id: coverage-percentage
+      run: |
+        COVERAGE=$(uv run coverage report --format=total)
+        echo "coverage=$COVERAGE" >> $GITHUB_OUTPUT
+        echo "Coverage percentage: $COVERAGE%"
+
+    - name: Create coverage badge
+      if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+      uses: schneegans/dynamic-badges-action@v1.7.0
+      with:
+        auth: ${{ secrets.GIST_SECRET }}
+        gistID: ${{ secrets.GIST_ID }}
+        filename: coverage.json
+        label: Coverage
+        message: ${{ steps.coverage-percentage.outputs.coverage }}%
+        valColorRange: ${{ steps.coverage-percentage.outputs.coverage }}
+        maxColorRange: 100
+        minColorRange: 0

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Sonarr Metadata Translation Layer
+# sonarr-metadata-rewrite
 
 ![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/kfstorm/2eafe27677e3a2ebbda29cbd026ff32b/raw/coverage.json)
 [![CI](https://github.com/kfstorm/sonarr-metadata-rewrite/actions/workflows/ci.yml/badge.svg)](https://github.com/kfstorm/sonarr-metadata-rewrite/actions/workflows/ci.yml)

--- a/README.md
+++ b/README.md
@@ -1,0 +1,6 @@
+# Sonarr Metadata Translation Layer
+
+![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/kfstorm/2eafe27677e3a2ebbda29cbd026ff32b/raw/coverage.json)
+[![CI](https://github.com/kfstorm/sonarr-metadata-rewrite/actions/workflows/ci.yml/badge.svg)](https://github.com/kfstorm/sonarr-metadata-rewrite/actions/workflows/ci.yml)
+
+Monitors Sonarr-generated .nfo files and overwrites them with TMDB translations in desired languages.


### PR DESCRIPTION
## Summary
- Fix python-coverage-comment-action to run only on pull requests, preventing failures on main branch pushes
- Add dynamic coverage badge generation for main branch using GitHub gist storage and shields.io
- Create minimal README with coverage and CI status badges that automatically update

## Changes
- Modified CI workflow to conditionally run coverage comment action only for pull requests
- Added coverage badge generation steps that run on main branch pushes
- Created README.md with dynamic coverage badge and basic project description

This resolves the CI failure where the coverage action tried to comment on non-existent pull requests when pushing to main.