### PR TITLE
Fix preferred languages configuration format and remove defaults

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,7 +48,7 @@ uv run sonarr-metadata-rewrite --version
 # Example with all optional settings
 TMDB_API_KEY=your_key \
 REWRITE_ROOT_DIR=/home/user/media \
-PREFERRED_LANGUAGES='["zh-CN","ja-JP"]' \
+PREFERRED_LANGUAGES='zh-CN,ja-JP' \
 CACHE_DURATION_HOURS=720 \
 PERIODIC_SCAN_INTERVAL_SECONDS=3600 \
 uv run sonarr-metadata-rewrite

--- a/src/sonarr_metadata_rewrite/config.py
+++ b/src/sonarr_metadata_rewrite/config.py
@@ -2,7 +2,7 @@
 
 from pathlib import Path
 
-from pydantic import Field, ValidationError
+from pydantic import Field, ValidationError, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -27,8 +27,8 @@ class Settings(BaseSettings):
     )
 
     # Translation preferences
-    preferred_languages: list[str] = Field(
-        default=["zh-CN"], description="Preferred languages in priority order"
+    preferred_languages: str = Field(
+        description="Preferred languages in priority order (comma-separated)"
     )
 
     # Universal caching configuration
@@ -45,6 +45,17 @@ class Settings(BaseSettings):
         default=Path("./backups"),
         description="Directory to backup original files (None disables backup)",
     )
+
+    @field_validator("preferred_languages")
+    @classmethod
+    def parse_preferred_languages(cls, v: str) -> list[str]:
+        """Parse preferred languages from comma-separated string."""
+        if isinstance(v, str):
+            languages = [lang.strip() for lang in v.split(",") if lang.strip()]
+            if not languages:
+                raise ValueError("preferred_languages cannot be empty")
+            return languages
+        raise ValueError("preferred_languages must be a comma-separated string")
 
 
 def get_settings() -> Settings:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -107,7 +107,7 @@ def test_settings(test_data_dir: Path) -> Settings:
     return Settings(
         tmdb_api_key="test_key_12345",
         rewrite_root_dir=test_data_dir,
-        preferred_languages=["zh-CN"],
+        preferred_languages="zh-CN",
         periodic_scan_interval_seconds=1,  # Fast interval for testing
         original_files_backup_dir=test_data_dir / "backups",
         cache_dir=test_data_dir / "cache",

--- a/tests/integration/test_sonarr_integration.py
+++ b/tests/integration/test_sonarr_integration.py
@@ -257,7 +257,7 @@ def test_sonarr_container_integration(
 
             settings = Settings(
                 rewrite_root_dir=temp_media_root,
-                preferred_languages=["zh-CN"],  # Chinese translation
+                preferred_languages="zh-CN",  # Chinese translation
                 periodic_scan_interval_seconds=1,  # Fast for testing
                 original_files_backup_dir=temp_path / "backups",
                 cache_dir=temp_path / "cache",

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -12,10 +12,11 @@ def test_settings_with_required_fields(test_data_dir: Path) -> None:
     settings = Settings(
         tmdb_api_key="test_api_key_1234567890abcdef",
         rewrite_root_dir=test_data_dir,
+        preferred_languages="zh-CN",
     )
     assert settings.tmdb_api_key == "test_api_key_1234567890abcdef"
     assert settings.rewrite_root_dir == test_data_dir
-    assert settings.preferred_languages == ["zh-CN"]  # default
+    assert settings.preferred_languages == ["zh-CN"]
     assert settings.periodic_scan_interval_seconds == 3600  # default
 
 
@@ -24,7 +25,7 @@ def test_settings_with_all_fields(test_data_dir: Path) -> None:
     settings = Settings(
         tmdb_api_key="test_key",
         rewrite_root_dir=test_data_dir,
-        preferred_languages=["ja-JP", "ko-KR"],
+        preferred_languages="ja-JP,ko-KR",
         periodic_scan_interval_seconds=1800,
         cache_duration_hours=168,
         cache_dir=test_data_dir / "custom_cache",
@@ -42,12 +43,13 @@ def test_get_settings_from_env(test_data_dir: Path) -> None:
     env_vars = {
         "TMDB_API_KEY": "env_test_key",
         "REWRITE_ROOT_DIR": str(test_data_dir),
-        "PREFERRED_LANGUAGES": '["en", "fr"]',
+        "PREFERRED_LANGUAGES": "en,fr",
     }
     with patch.dict(os.environ, env_vars):
         settings = get_settings()
         assert settings.tmdb_api_key == "env_test_key"
         assert settings.rewrite_root_dir == test_data_dir
+        assert settings.preferred_languages == ["en", "fr"]
 
 
 def test_settings_backup_disabled(test_data_dir: Path) -> None:
@@ -55,6 +57,60 @@ def test_settings_backup_disabled(test_data_dir: Path) -> None:
     settings = Settings(
         tmdb_api_key="test_key",
         rewrite_root_dir=test_data_dir,
+        preferred_languages="zh-CN",
         original_files_backup_dir=None,
     )
     assert settings.original_files_backup_dir is None
+
+
+def test_preferred_languages_comma_separated() -> None:
+    """Test preferred_languages parsing from comma-separated string."""
+    from pathlib import Path
+
+    settings = Settings(
+        tmdb_api_key="test_key",
+        rewrite_root_dir=Path("/tmp"),
+        preferred_languages="zh-CN, ja-JP , ko-KR",
+    )
+    assert settings.preferred_languages == ["zh-CN", "ja-JP", "ko-KR"]
+
+
+def test_preferred_languages_single_language() -> None:
+    """Test preferred_languages with single language."""
+    from pathlib import Path
+
+    settings = Settings(
+        tmdb_api_key="test_key",
+        rewrite_root_dir=Path("/tmp"),
+        preferred_languages="fr",
+    )
+    assert settings.preferred_languages == ["fr"]
+
+
+def test_preferred_languages_empty_string_fails() -> None:
+    """Test preferred_languages with empty string fails validation."""
+    from pathlib import Path
+
+    import pytest
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        Settings(
+            tmdb_api_key="test_key",
+            rewrite_root_dir=Path("/tmp"),
+            preferred_languages="",
+        )
+
+
+def test_preferred_languages_required_field() -> None:
+    """Test preferred_languages is required."""
+    from pathlib import Path
+
+    import pytest
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        Settings(
+            tmdb_api_key="test_key",
+            rewrite_root_dir=Path("/tmp"),
+        )

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -17,7 +17,11 @@ class TestCli:
         runner = CliRunner()
 
         with runner.isolated_filesystem():
-            env_vars = {"TMDB_API_KEY": test_key, "REWRITE_ROOT_DIR": "/tmp/test"}
+            env_vars = {
+                "TMDB_API_KEY": test_key,
+                "REWRITE_ROOT_DIR": "/tmp/test",
+                "PREFERRED_LANGUAGES": "zh-CN",
+            }
             with patch.dict(os.environ, env_vars):
                 # Mock the service to avoid actually starting it
                 with patch(

--- a/tests/unit/test_metadata_processor.py
+++ b/tests/unit/test_metadata_processor.py
@@ -274,3 +274,221 @@ def test_apply_fallback_to_translation_both_empty(
         "high school chemistry teacher" in result.description
     )  # Original description from test data
     assert result.language == "zh-CN"
+
+
+def test_process_file_multiple_preferred_languages_first_match(
+    test_data_dir: Path,
+    create_test_files: Callable[[str, Path], Path],
+) -> None:
+    """Test that first available preferred language is selected."""
+    from unittest.mock import Mock
+
+    from sonarr_metadata_rewrite.config import Settings
+    from sonarr_metadata_rewrite.metadata_processor import MetadataProcessor
+    from sonarr_metadata_rewrite.models import TranslatedContent
+
+    # Setup settings with multiple preferred languages
+    settings = Settings(
+        tmdb_api_key="test_key_12345",
+        rewrite_root_dir=test_data_dir,
+        preferred_languages="ko-KR,ja-JP,zh-CN",  # Korean -> Japanese -> Chinese
+        periodic_scan_interval_seconds=1,
+        original_files_backup_dir=test_data_dir / "backups",
+        cache_dir=test_data_dir / "cache",
+    )
+
+    # Mock translator with available translations (missing Korean)
+    mock_translator = Mock()
+    mock_translator.get_translations.return_value = {
+        "ja-JP": TranslatedContent("日本語タイトル", "日本語の説明", "ja-JP"),
+        "zh-CN": TranslatedContent("中文标题", "中文描述", "zh-CN"),
+        "en": TranslatedContent("English Title", "English Description", "en"),
+    }
+
+    processor = MetadataProcessor(settings, mock_translator)
+    test_path = create_test_files("tvshow.nfo", test_data_dir / "test_multi_lang.nfo")
+
+    result = processor.process_file(test_path)
+
+    # Should select Japanese (ja-JP) as it's first available in preferred languages
+    assert_process_result(
+        result,
+        expected_success=True,
+        expected_language="ja-JP",  # Should pick Japanese, not Chinese
+        expected_file_modified=True,
+        expected_message_contains="Successfully translated",
+    )
+
+
+def test_process_file_multiple_preferred_languages_no_matches(
+    test_data_dir: Path,
+    create_test_files: Callable[[str, Path], Path],
+) -> None:
+    """Test when none of the preferred languages are available."""
+    from unittest.mock import Mock
+
+    from sonarr_metadata_rewrite.config import Settings
+    from sonarr_metadata_rewrite.metadata_processor import MetadataProcessor
+    from sonarr_metadata_rewrite.models import TranslatedContent
+
+    # Setup settings with preferred languages that don't match available translations
+    settings = Settings(
+        tmdb_api_key="test_key_12345",
+        rewrite_root_dir=test_data_dir,
+        preferred_languages="ko-KR,th-TH,vi-VN",  # Korean, Thai, Vietnamese
+        periodic_scan_interval_seconds=1,
+        original_files_backup_dir=test_data_dir / "backups",
+        cache_dir=test_data_dir / "cache",
+    )
+
+    # Mock translator with only different languages available
+    mock_translator = Mock()
+    mock_translator.get_translations.return_value = {
+        "ja-JP": TranslatedContent("日本語タイトル", "日本語の説明", "ja-JP"),
+        "zh-CN": TranslatedContent("中文标题", "中文描述", "zh-CN"),
+        "en": TranslatedContent("English Title", "English Description", "en"),
+        "fr": TranslatedContent("Titre français", "Description française", "fr"),
+    }
+
+    processor = MetadataProcessor(settings, mock_translator)
+    test_path = create_test_files("tvshow.nfo", test_data_dir / "test_no_preferred.nfo")
+
+    result = processor.process_file(test_path)
+
+    # Should fail with detailed message about preferred vs available languages
+    assert result.success is False
+    assert result.file_modified is False
+    assert result.selected_language is None
+    assert "preferred languages [ko-KR, th-TH, vi-VN]" in result.message
+    assert "Available: [en, fr, ja-JP, zh-CN]" in result.message  # Should be sorted
+    assert "File unchanged" in result.message
+
+
+def test_process_file_multiple_preferred_languages_partial_matches(
+    test_data_dir: Path,
+    create_test_files: Callable[[str, Path], Path],
+) -> None:
+    """Test when some but not all preferred languages are available."""
+    from unittest.mock import Mock
+
+    from sonarr_metadata_rewrite.config import Settings
+    from sonarr_metadata_rewrite.metadata_processor import MetadataProcessor
+    from sonarr_metadata_rewrite.models import TranslatedContent
+
+    # Setup settings with mixed preferred languages (some available, some not)
+    settings = Settings(
+        tmdb_api_key="test_key_12345",
+        rewrite_root_dir=test_data_dir,
+        preferred_languages="ar,zh-CN,th-TH,ja-JP",  # Arabic, Chinese, Thai, Japanese
+        periodic_scan_interval_seconds=1,
+        original_files_backup_dir=test_data_dir / "backups",
+        cache_dir=test_data_dir / "cache",
+    )
+
+    # Mock translator with some matching languages (missing Arabic and Thai)
+    mock_translator = Mock()
+    mock_translator.get_translations.return_value = {
+        "zh-CN": TranslatedContent("中文标题", "中文描述", "zh-CN"),
+        "ja-JP": TranslatedContent("日本語タイトル", "日本語の説明", "ja-JP"),
+        "en": TranslatedContent("English Title", "English Description", "en"),
+        "de": TranslatedContent("Deutscher Titel", "Deutsche Beschreibung", "de"),
+    }
+
+    processor = MetadataProcessor(settings, mock_translator)
+    test_path = create_test_files(
+        "tvshow.nfo", test_data_dir / "test_partial_match.nfo"
+    )
+
+    result = processor.process_file(test_path)
+
+    # Should select Chinese (zh-CN) as it's the first available in preferred order
+    assert_process_result(
+        result,
+        expected_success=True,
+        expected_language="zh-CN",  # Should pick Chinese, not Japanese
+        expected_file_modified=True,
+        expected_message_contains="Successfully translated",
+    )
+
+
+def test_process_file_single_preferred_language_available(
+    test_data_dir: Path,
+    create_test_files: Callable[[str, Path], Path],
+) -> None:
+    """Test when only one preferred language is specified and it's available."""
+    from unittest.mock import Mock
+
+    from sonarr_metadata_rewrite.config import Settings
+    from sonarr_metadata_rewrite.metadata_processor import MetadataProcessor
+    from sonarr_metadata_rewrite.models import TranslatedContent
+
+    settings = Settings(
+        tmdb_api_key="test_key_12345",
+        rewrite_root_dir=test_data_dir,
+        preferred_languages="fr",  # Only French
+        periodic_scan_interval_seconds=1,
+        original_files_backup_dir=test_data_dir / "backups",
+        cache_dir=test_data_dir / "cache",
+    )
+
+    mock_translator = Mock()
+    mock_translator.get_translations.return_value = {
+        "fr": TranslatedContent("Titre français", "Description française", "fr"),
+        "en": TranslatedContent("English Title", "English Description", "en"),
+        "de": TranslatedContent("Deutscher Titel", "Deutsche Beschreibung", "de"),
+    }
+
+    processor = MetadataProcessor(settings, mock_translator)
+    test_path = create_test_files("tvshow.nfo", test_data_dir / "test_single_lang.nfo")
+
+    result = processor.process_file(test_path)
+
+    assert_process_result(
+        result,
+        expected_success=True,
+        expected_language="fr",
+        expected_file_modified=True,
+        expected_message_contains="Successfully translated",
+    )
+
+
+def test_process_file_single_preferred_language_not_available(
+    test_data_dir: Path,
+    create_test_files: Callable[[str, Path], Path],
+) -> None:
+    """Test when only one preferred language is specified and it's not available."""
+    from unittest.mock import Mock
+
+    from sonarr_metadata_rewrite.config import Settings
+    from sonarr_metadata_rewrite.metadata_processor import MetadataProcessor
+    from sonarr_metadata_rewrite.models import TranslatedContent
+
+    settings = Settings(
+        tmdb_api_key="test_key_12345",
+        rewrite_root_dir=test_data_dir,
+        preferred_languages="ar",  # Only Arabic
+        periodic_scan_interval_seconds=1,
+        original_files_backup_dir=test_data_dir / "backups",
+        cache_dir=test_data_dir / "cache",
+    )
+
+    mock_translator = Mock()
+    mock_translator.get_translations.return_value = {
+        "fr": TranslatedContent("Titre français", "Description française", "fr"),
+        "en": TranslatedContent("English Title", "English Description", "en"),
+        "zh-CN": TranslatedContent("中文标题", "中文描述", "zh-CN"),
+    }
+
+    processor = MetadataProcessor(settings, mock_translator)
+    test_path = create_test_files(
+        "tvshow.nfo", test_data_dir / "test_single_missing.nfo"
+    )
+
+    result = processor.process_file(test_path)
+
+    assert result.success is False
+    assert result.file_modified is False
+    assert result.selected_language is None
+    assert "preferred languages [ar]" in result.message
+    assert "Available: [en, fr, zh-CN]" in result.message
+    assert "File unchanged" in result.message

--- a/vulture_whitelist.py
+++ b/vulture_whitelist.py
@@ -4,6 +4,10 @@
 # Pydantic model_config is used by the framework
 _.model_config
 
+# Pydantic validators are used by the framework
+_.parse_preferred_languages
+_.cls
+
 # Signal handler parameters are required by the interface
 _.signum
 _.frame


### PR DESCRIPTION
## Summary

This PR fixes the preferred languages configuration to address the following requirements:
- Remove `zh-CN` as default language (now required field)
- Use comma-separated format instead of JSON for `PREFERRED_LANGUAGES` environment variable
- Add comprehensive unit test coverage for multiple preferred languages scenarios

## Changes Made

### Configuration Updates
- **config.py**: Removed default value `["zh-CN"]` and made `preferred_languages` a required string field
- **Environment Variable Format**: Changed from JSON `'["zh-CN","ja-JP"]'` to comma-separated `"zh-CN,ja-JP"`
- **Custom Validator**: Added Pydantic validator to parse comma-separated strings with whitespace handling

### Enhanced Test Coverage
Added 5 comprehensive test cases for multiple preferred languages scenarios:
- **First Match Selection**: Tests that the first available language from preferences is selected
- **No Matches**: Tests behavior when none of the preferred languages are available
- **Partial Matches**: Tests scenarios where some preferred languages are available, some aren't
- **Single Language**: Tests single preferred language scenarios (available/not available)
- **Validation**: Tests required field validation and empty string rejection

### Documentation & Code Quality
- **CLAUDE.md**: Updated documentation to show comma-separated format
- **All Tests Updated**: Fixed all test fixtures and integration tests to use new string format
- **Linting**: All code quality checks pass (Black, Ruff, MyPy, Vulture, Tach)
- **Coverage**: 61/61 unit tests passing with 88% test coverage

## Test Results

✅ **All 61 unit tests pass**  
✅ **All linting checks pass**  
✅ **Comprehensive language selection scenarios covered**

## Usage Examples

**Before (JSON format):**
```bash
PREFERRED_LANGUAGES='["zh-CN","ja-JP"]'
```

**After (comma-separated):**
```bash
PREFERRED_LANGUAGES="zh-CN,ja-JP,ko-KR"
```

The new format is simpler, more intuitive, and handles whitespace automatically.