### PR TITLE
Add rollback mechanism test and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,43 @@
 [![CI](https://github.com/kfstorm/sonarr-metadata-rewrite/actions/workflows/ci.yml/badge.svg)](https://github.com/kfstorm/sonarr-metadata-rewrite/actions/workflows/ci.yml)
 
 Monitors Sonarr-generated .nfo files and overwrites them with TMDB translations in desired languages.
+
+## Rollback to Original Metadata
+
+If you want to restore the original English metadata from Sonarr:
+
+### Method 1: Using Sonarr UI
+1. **Stop the translation service**
+2. **Delete translated .nfo files** from your series directories
+3. **Go to Sonarr > Series > [Select Series] > Refresh Series**
+4. Sonarr will regenerate original English .nfo files
+
+### Method 2: Using Command Line
+```bash
+# Stop the service first
+# Then delete .nfo files and refresh via API
+curl -X POST "http://localhost:8989/api/v3/command" \
+  -H "X-Api-Key: YOUR_SONARR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"name": "RefreshSeries", "seriesId": SERIES_ID}'
+```
+
+### Method 3: Bulk Rollback Script
+```bash
+#!/bin/bash
+# Example script to rollback all series
+MEDIA_ROOT="/path/to/your/media"
+SONARR_URL="http://localhost:8989"
+SONARR_API_KEY="your_api_key"
+
+# Find and delete all .nfo files
+find "$MEDIA_ROOT" -name "*.nfo" -delete
+
+# Trigger refresh for all series
+curl -X POST "$SONARR_URL/api/v3/command" \
+  -H "X-Api-Key: $SONARR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"name": "RefreshSeries"}'
+```
+
+**Important**: Always stop the translation service before performing rollback operations to prevent it from immediately retranslating the restored files.

--- a/TODO.md
+++ b/TODO.md
@@ -18,7 +18,7 @@ Create a compatibility layer that monitors Sonarr-generated .nfo files and overw
 
 ### 💾 Backup & Recovery
 - [x] **Original File Preservation**: Keep backups of original Sonarr-generated files
-- [ ] **Rollback Capability**: Ability to restore original English metadata if needed
+- [x] **Rollback Capability**: Ability to restore original English metadata if needed
 - [x] **Safe File Operations**: Prevent data loss through atomic file operations
 
 ## Advanced Features


### PR DESCRIPTION
## Summary
- Add comprehensive rollback mechanism test to verify users can restore original English metadata
- Provide detailed rollback documentation with multiple methods
- Refactor integration tests to eliminate code duplication

## Rollback Test Implementation
This PR adds a new test scenario `rollback_mechanism` that validates the complete rollback workflow:

1. **Store original metadata** - Capture English metadata before any translations
2. **Run translation service** - Verify files get translated to Chinese
3. **Stop service** - Ensure service shuts down completely  
4. **Delete translated files** - Remove .nfo files to force regeneration
5. **Trigger Sonarr refresh** - Use Sonarr API to regenerate original files
6. **Verify rollback** - Confirm restored files match original English metadata

This test ensures users can reliably restore original metadata when needed.

## Documentation Updates
Added comprehensive rollback instructions to README.md with three methods:

### Method 1: Using Sonarr UI
- Manual approach through Sonarr's web interface
- User-friendly for individual series

### Method 2: Using Command Line  
- API-based approach for specific series
- Suitable for scripting single series rollback

### Method 3: Bulk Rollback Script
- Complete automation for all series
- Production-ready script for mass rollback operations

## Test Code Improvements
Extracted helper functions to eliminate ~50 lines of duplicated code:
- `is_translated()` - Detect Chinese character translations
- `count_translations()` - Count translated NFO files
- `metadata_matches()` - Compare metadata dictionaries  
- `wait_and_verify_translations()` - Wait and verify translation patterns

## Test plan
- [x] All integration tests pass (4/4 scenarios)
- [x] Unit tests continue to pass (61/61)
- [x] Code quality checks pass (Black, Ruff, MyPy, Vulture, Tach)
- [x] Rollback test validates complete workflow end-to-end
- [x] Documentation provides clear user instructions