### PR TITLE
Change default scan interval from 1 hour to 1 day

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,7 +52,7 @@ uv run sonarr-metadata-rewrite --version
 REWRITE_ROOT_DIR=/home/user/media \
 PREFERRED_LANGUAGES='zh-CN,ja-JP' \
 CACHE_DURATION_HOURS=720 \
-PERIODIC_SCAN_INTERVAL_SECONDS=3600 \
+PERIODIC_SCAN_INTERVAL_SECONDS=86400 \
 uv run sonarr-metadata-rewrite
 ```
 

--- a/src/sonarr_metadata_rewrite/config.py
+++ b/src/sonarr_metadata_rewrite/config.py
@@ -23,7 +23,7 @@ class Settings(BaseSettings):
         description="Root directory to monitor and rewrite .nfo files"
     )
     periodic_scan_interval_seconds: int = Field(
-        default=3600, description="How often to scan the directory (seconds)"
+        default=86400, description="How often to scan the directory (seconds)"
     )
 
     # Translation preferences

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -17,7 +17,7 @@ def test_settings_with_required_fields(test_data_dir: Path) -> None:
     assert settings.tmdb_api_key == "test_api_key_1234567890abcdef"
     assert settings.rewrite_root_dir == test_data_dir
     assert settings.preferred_languages == ["zh-CN"]
-    assert settings.periodic_scan_interval_seconds == 3600  # default
+    assert settings.periodic_scan_interval_seconds == 86400  # default
 
 
 def test_settings_with_all_fields(test_data_dir: Path) -> None:


### PR DESCRIPTION
## Summary
• Update default periodic scan interval from 3600 seconds (1 hour) to 86400 seconds (24 hours)
• Update corresponding test expectation and documentation example
• Maintains backward compatibility via environment variable override

## Test plan
- [x] Unit tests pass with updated expectations
- [x] Pre-commit hooks pass (linting, formatting, tests)
- [x] No breaking changes to existing functionality