### PR TITLE
Add Docker --user parameter documentation to prevent file permission issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,10 +114,12 @@ order.
 
 ### File Permissions (Important!)
 
-The `--user` parameter in the Docker examples above is **critical** for maintaining proper file permissions. Here's why:
+The `--user` parameter in the Docker examples above is **critical** for
+maintaining proper file permissions. Here's why:
 
 - Without `--user`, Docker runs the container as root by default
-- Files created by the container (rewritten .nfo files, cache, backups) will be owned by root
+- Files created by the container (rewritten .nfo files, cache, backups) will be
+  owned by root
 - This can cause permission issues when trying to access files from your host system
 - Sonarr or other applications may not be able to read the rewritten files
 

--- a/README.md
+++ b/README.md
@@ -122,16 +122,21 @@ The `--user` parameter in the Docker examples above is **critical** for maintain
 - Sonarr or other applications may not be able to read the rewritten files
 
 **For Docker run:**
+
 ```bash
 --user $(id -u):$(id -g)
 ```
+
 This automatically uses your current user's UID and GID.
 
 **For Docker Compose:**
+
 ```yaml
 user: "${UID:-1000}:${GID:-1000}"
 ```
+
 Set the UID and GID environment variables first:
+
 ```bash
 export UID=$(id -u)
 export GID=$(id -g)
@@ -139,6 +144,7 @@ docker compose up -d
 ```
 
 **To check your user ID:**
+
 ```bash
 id -u  # Shows your user ID (UID)
 id -g  # Shows your group ID (GID)
@@ -289,6 +295,7 @@ If you're seeing permission denied errors or files owned by root:
 - Files should be owned by your user, not root
 
 **Fix for existing root-owned files:**
+
 ```bash
 # Stop the container first
 docker stop sonarr-metadata-rewrite


### PR DESCRIPTION
## Summary
- Add `--user` parameter to Docker run and Docker Compose examples
- Add comprehensive file permissions section explaining why this is critical
- Add troubleshooting section for file permission issues

## Changes Made
- Updated Docker run command with `--user $(id -u):$(id -g)`
- Updated Docker Compose example with `user: "${UID:-1000}:${GID:-1000}"`
- Added detailed "File Permissions (Important!)" section explaining the importance of proper user mapping
- Added "File permission issues" troubleshooting section with diagnostic and fix commands

## Why This Matters
Without the `--user` parameter, Docker containers run as root by default, causing:
- Rewritten .nfo files to be owned by root
- Permission denied errors when host applications try to access files
- Sonarr and other media applications unable to read the translated metadata

## Resolves
Fixes #16 - Ensure owner/group won't change after rewrite

## Test Plan
- [x] Verified documentation formatting and clarity
- [x] Tested Docker commands work with proper user mapping
- [x] Confirmed troubleshooting steps resolve permission issues