### PR TITLE
Optimize unit test performance and improve code organization

### DIFF
--- a/src/sonarr_metadata_rewrite/rollback_service.py
+++ b/src/sonarr_metadata_rewrite/rollback_service.py
@@ -2,6 +2,7 @@
 
 import logging
 import shutil
+import time
 from pathlib import Path
 
 from sonarr_metadata_rewrite.config import Settings
@@ -115,8 +116,6 @@ class RollbackService:
 
         try:
             while True:
-                import time
-
                 time.sleep(60)  # Sleep for 1 minute at a time
         except KeyboardInterrupt:
             logger.info("Received interrupt signal, shutting down gracefully")

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -4,6 +4,9 @@ import os
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
+from pydantic import ValidationError
+
 from sonarr_metadata_rewrite.config import Settings, get_settings
 
 
@@ -66,7 +69,6 @@ def test_settings_backup_disabled(test_data_dir: Path) -> None:
 
 def test_preferred_languages_comma_separated() -> None:
     """Test preferred_languages parsing from comma-separated string."""
-    from pathlib import Path
 
     settings = Settings(
         tmdb_api_key="test_key",
@@ -78,7 +80,6 @@ def test_preferred_languages_comma_separated() -> None:
 
 def test_preferred_languages_single_language() -> None:
     """Test preferred_languages with single language."""
-    from pathlib import Path
 
     settings = Settings(
         tmdb_api_key="test_key",
@@ -90,10 +91,6 @@ def test_preferred_languages_single_language() -> None:
 
 def test_preferred_languages_empty_string_fails() -> None:
     """Test preferred_languages with empty string fails validation."""
-    from pathlib import Path
-
-    import pytest
-    from pydantic import ValidationError
 
     with pytest.raises(ValidationError):
         Settings(
@@ -105,10 +102,6 @@ def test_preferred_languages_empty_string_fails() -> None:
 
 def test_preferred_languages_required_field() -> None:
     """Test preferred_languages is required."""
-    from pathlib import Path
-
-    import pytest
-    from pydantic import ValidationError
 
     with pytest.raises(ValidationError):
         Settings(
@@ -151,10 +144,6 @@ def test_service_mode_rollback(test_data_dir: Path) -> None:
 
 def test_service_mode_invalid_value_fails() -> None:
     """Test service_mode with invalid value fails validation."""
-    from pathlib import Path
-
-    import pytest
-    from pydantic import ValidationError
 
     with pytest.raises(ValidationError):
         Settings(

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -58,14 +58,17 @@ class TestCli:
         assert result.exit_code == 0
         assert "version" in result.output
         # Version format should be semantic version or dev version
+        import re
+
+        # Check for either semantic version (x.y.z) or development version
+        version_patterns = [
+            r"version \d+\.\d+\.\d+",  # Semantic version like "version 1.0.2"
+            r"dev",  # Development version
+            r"\+g[0-9a-f]+",  # Git commit hash in version
+        ]
         assert any(
-            pattern in result.output
-            for pattern in [
-                "version 0.",
-                "dev",
-                "+g",
-            ]  # Covers both release and dev versions
-        )
+            re.search(pattern, result.output) for pattern in version_patterns
+        ), f"Version output '{result.output.strip()}' doesn't match expected patterns"
 
     def test_cli_help(self) -> None:
         """Test CLI help option."""

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -1,6 +1,7 @@
 """Unit tests for main CLI module."""
 
 import os
+import re
 from unittest.mock import patch
 
 from click.testing import CliRunner
@@ -58,7 +59,6 @@ class TestCli:
         assert result.exit_code == 0
         assert "version" in result.output
         # Version format should be semantic version or dev version
-        import re
 
         # Check for either semantic version (x.y.z) or development version
         version_patterns = [

--- a/tests/unit/test_metadata_processor.py
+++ b/tests/unit/test_metadata_processor.py
@@ -319,12 +319,6 @@ def test_process_file_multiple_preferred_languages_first_match(
     create_test_files: Callable[[str, Path], Path],
 ) -> None:
     """Test that first available preferred language is selected."""
-    from unittest.mock import Mock
-
-    from sonarr_metadata_rewrite.config import Settings
-    from sonarr_metadata_rewrite.metadata_processor import MetadataProcessor
-    from sonarr_metadata_rewrite.models import TranslatedContent
-
     # Setup settings with multiple preferred languages
     settings = Settings(
         tmdb_api_key="test_key_12345",
@@ -363,12 +357,6 @@ def test_process_file_multiple_preferred_languages_no_matches(
     create_test_files: Callable[[str, Path], Path],
 ) -> None:
     """Test when none of the preferred languages are available."""
-    from unittest.mock import Mock
-
-    from sonarr_metadata_rewrite.config import Settings
-    from sonarr_metadata_rewrite.metadata_processor import MetadataProcessor
-    from sonarr_metadata_rewrite.models import TranslatedContent
-
     # Setup settings with preferred languages that don't match available translations
     settings = Settings(
         tmdb_api_key="test_key_12345",
@@ -407,12 +395,6 @@ def test_process_file_multiple_preferred_languages_partial_matches(
     create_test_files: Callable[[str, Path], Path],
 ) -> None:
     """Test when some but not all preferred languages are available."""
-    from unittest.mock import Mock
-
-    from sonarr_metadata_rewrite.config import Settings
-    from sonarr_metadata_rewrite.metadata_processor import MetadataProcessor
-    from sonarr_metadata_rewrite.models import TranslatedContent
-
     # Setup settings with mixed preferred languages (some available, some not)
     settings = Settings(
         tmdb_api_key="test_key_12345",
@@ -454,11 +436,6 @@ def test_process_file_single_preferred_language_available(
     create_test_files: Callable[[str, Path], Path],
 ) -> None:
     """Test when only one preferred language is specified and it's available."""
-    from unittest.mock import Mock
-
-    from sonarr_metadata_rewrite.config import Settings
-    from sonarr_metadata_rewrite.metadata_processor import MetadataProcessor
-    from sonarr_metadata_rewrite.models import TranslatedContent
 
     settings = Settings(
         tmdb_api_key="test_key_12345",
@@ -495,11 +472,6 @@ def test_process_file_single_preferred_language_not_available(
     create_test_files: Callable[[str, Path], Path],
 ) -> None:
     """Test when only one preferred language is specified and it's not available."""
-    from unittest.mock import Mock
-
-    from sonarr_metadata_rewrite.config import Settings
-    from sonarr_metadata_rewrite.metadata_processor import MetadataProcessor
-    from sonarr_metadata_rewrite.models import TranslatedContent
 
     settings = Settings(
         tmdb_api_key="test_key_12345",

--- a/tests/unit/test_translator.py
+++ b/tests/unit/test_translator.py
@@ -594,8 +594,9 @@ def test_rate_limit_exponential_backoff_max_delay(
 
 
 @patch("httpx.Client.get")
+@patch("time.sleep")
 def test_rate_limit_preserves_cache_on_failure(
-    mock_get: Mock, translator: Translator
+    mock_sleep: Mock, mock_get: Mock, translator: Translator
 ) -> None:
     """Test that rate limit failures don't corrupt cache."""
     # Rate limit error for all attempts


### PR DESCRIPTION
## Summary
- Optimized unit test performance by mocking time.sleep in rate limit tests
- Moved all imports to top of files following Python conventions
- Fixed unit test version assertion to handle semantic versions properly
- Removed redundant code and improved test organization

## Test plan
- [x] All unit tests pass with improved performance
- [x] Integration tests continue to work correctly
- [x] Linting and type checking pass
- [x] Code follows Python import conventions