### PR TITLE
Fix GitHub Actions job skipping issue in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -153,7 +153,7 @@ jobs:
       DOCKER_HUB_TOKEN: ${{ secrets.DOCKER_HUB_TOKEN }}
 
   update-docker-hub-description:
-    if: startsWith(github.ref, 'refs/tags/v')
+    if: startsWith(github.ref, 'refs/tags/v') && !failure() && !cancelled()
     needs: build-and-push
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary

- Fix update-docker-hub-description job being unexpectedly skipped during tag releases
- Add conditional logic to handle skipped dependencies in GitHub Actions workflow

## Problem

In workflow run [#17340909390](https://github.com/kfstorm/sonarr-metadata-rewrite/actions/runs/17340909390), the `update-docker-hub-description` job was skipped despite the `build-and-push` job completing successfully. This occurred because:

1. `check-changes` job was skipped (only runs on schedule events)  
2. `build-and-push` job succeeded (has `always()` condition to handle skipped dependency)
3. `update-docker-hub-description` job was unexpectedly skipped due to a known GitHub Actions limitation

## Root Cause

This is a documented issue in [GitHub Actions Runner #2205](https://github.com/actions/runner/issues/2205) where jobs can be skipped when there are skipped jobs in the dependency chain, even when intermediate dependencies succeed.

## Solution

Updated the `update-docker-hub-description` job condition from:
```yaml
if: startsWith(github.ref, 'refs/tags/v')
```
to:
```yaml  
if: startsWith(github.ref, 'refs/tags/v') && !failure() && !cancelled()
```

This ensures the job runs when its direct dependency (`build-and-push`) succeeds, regardless of upstream skipped jobs.

## Test Plan

- [x] Verify workflow syntax is valid
- [ ] Test with next tag release to confirm Docker Hub description updates properly
- [ ] Monitor that nightly builds continue to work correctly (should be unaffected)