### PR TITLE
Fix nightly Docker build change detection for OCI Image Index format

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
           exit 0
         fi
 
-        # Get nightly image manifest
+        # Get nightly image manifest (OCI Image Index)
         manifest_response=$(curl -s -H "Accept: application/vnd.docker.distribution.manifest.v2+json" -H "Authorization: Bearer $token" "https://registry-1.docker.io/v2/kfstorm/sonarr-metadata-rewrite/manifests/nightly")
         if [ $? -ne 0 ] || [ -z "$manifest_response" ]; then
           echo "No nightly image found or failed to fetch manifest, proceeding with build"
@@ -57,7 +57,17 @@ jobs:
           exit 0
         fi
 
-        config_digest=$(echo "$manifest_response" | jq -r '.config.digest // empty')
+        # Get first platform manifest from OCI Image Index
+        first_manifest_digest=$(echo "$manifest_response" | jq -r '.manifests[0].digest')
+        if [ -z "$first_manifest_digest" ] || [ "$first_manifest_digest" = "null" ]; then
+          echo "No platform manifest found, proceeding with build"
+          echo "skip=false" >> $GITHUB_OUTPUT
+          exit 0
+        fi
+
+        # Get platform-specific manifest to find config digest
+        platform_manifest=$(curl -s -H "Accept: application/vnd.oci.image.manifest.v1+json" -H "Authorization: Bearer $token" "https://registry-1.docker.io/v2/kfstorm/sonarr-metadata-rewrite/manifests/$first_manifest_digest")
+        config_digest=$(echo "$platform_manifest" | jq -r '.config.digest // empty')
         if [ -z "$config_digest" ] || [ "$config_digest" = "null" ]; then
           echo "No config digest found, proceeding with build"
           echo "skip=false" >> $GITHUB_OUTPUT
@@ -67,7 +77,7 @@ jobs:
         echo "Config digest: $config_digest"
 
         # Get image config with labels
-        config_response=$(curl -s -H "Authorization: Bearer $token" "https://registry-1.docker.io/v2/kfstorm/sonarr-metadata-rewrite/blobs/$config_digest")
+        config_response=$(curl -L -s -H "Authorization: Bearer $token" "https://registry-1.docker.io/v2/kfstorm/sonarr-metadata-rewrite/blobs/$config_digest")
         if [ $? -ne 0 ] || [ -z "$config_response" ]; then
           echo "Failed to fetch image config, proceeding with build"
           echo "skip=false" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary

- Fix nightly Docker build change detection to properly handle OCI Image Index format
- Update manifest parsing logic to extract config digest from multi-platform images
- Add redirect following for Docker Hub blob requests

## Problem

The nightly Docker build workflow was always proceeding with builds because it couldn't parse the multi-platform image manifest returned by Docker Hub. The workflow expected a simple manifest with `config.digest` field, but Docker Hub returns an OCI Image Index with a `manifests[]` array for multi-platform images.

This caused the "No config digest found" error in the check-changes job, making change detection ineffective.

## Solution

Updated the workflow to:
1. Parse OCI Image Index format with `manifests[]` array
2. Extract the first platform manifest digest
3. Fetch the platform-specific manifest to get the actual `config.digest`
4. Follow redirects when fetching config blobs from Docker Hub

## Test Plan

- [x] Manually verified Docker Hub API calls work with new logic
- [x] Confirmed image labels contain proper `org.opencontainers.image.revision`
- [x] Tested commit comparison logic
- [ ] Verify workflow runs correctly on next scheduled build