### PR TITLE
Support Sonarr multi-episode NFO files

### DIFF
--- a/src/sonarr_metadata_rewrite/file_utils.py
+++ b/src/sonarr_metadata_rewrite/file_utils.py
@@ -166,9 +166,6 @@ def _parse_nfo_documents(nfo_path: Path) -> MetadataInfo:
     if all(child.tag == "episodedetails" for child in wrapped_root):
         return _extract_episode_metadata(wrapped_root)
 
-    if len(wrapped_root) == 1 and wrapped_root[0].tag == "episodedetails":
-        return _extract_episode_metadata(wrapped_root)
-
     raise ET.ParseError("Unsupported NFO root structure")
 
 

--- a/src/sonarr_metadata_rewrite/file_utils.py
+++ b/src/sonarr_metadata_rewrite/file_utils.py
@@ -9,7 +9,7 @@ import xml.etree.ElementTree as ET
 from pathlib import Path
 from xml.etree.ElementTree import ElementTree  # noqa: F401
 
-from sonarr_metadata_rewrite.models import MetadataInfo
+from sonarr_metadata_rewrite.models import EpisodeMetadataInfo, MetadataInfo
 from sonarr_metadata_rewrite.retry_utils import retry
 
 # Supported image extensions (lowercase with leading dot)
@@ -111,14 +111,14 @@ def is_target_file(file_path: Path) -> bool:
     return is_nfo_file(file_path) or is_rewritable_image(file_path)
 
 
-def parse_nfo_with_retry(nfo_path: Path) -> "ElementTree[ET.Element]":
+def parse_nfo_with_retry(nfo_path: Path) -> MetadataInfo:
     """Parse NFO file with retry logic for incomplete/corrupt files.
 
     Args:
         nfo_path: Path to .nfo file to parse
 
     Returns:
-        Parsed XML tree
+        Parsed metadata information
 
     Raises:
         ET.ParseError: If file remains corrupt after retries
@@ -131,8 +131,8 @@ def parse_nfo_with_retry(nfo_path: Path) -> "ElementTree[ET.Element]":
         log_interval=3.0,
         exceptions=(ET.ParseError, OSError),
     )
-    def parse_file() -> "ElementTree[ET.Element]":
-        return ET.parse(nfo_path)
+    def parse_file() -> MetadataInfo:
+        return _parse_nfo_documents(nfo_path)
 
     return parse_file()
 
@@ -146,19 +146,93 @@ def extract_metadata_info(nfo_path: Path) -> MetadataInfo:
     Returns:
         MetadataInfo object with all extracted data
     """
-    tree = parse_nfo_with_retry(nfo_path)
-    root = tree.getroot()
+    return parse_nfo_with_retry(nfo_path)
 
-    # Determine file type from root tag
-    file_type = root.tag if root.tag in ("tvshow", "episodedetails") else "unknown"
 
-    info = MetadataInfo(file_type=file_type, xml_tree=tree)  # type: ignore[arg-type]
+def _parse_nfo_documents(nfo_path: Path) -> MetadataInfo:
+    """Parse one or more adjacent XML documents from an NFO file."""
+    raw_content = nfo_path.read_text(encoding="utf-8")
+    normalized_content = raw_content.strip()
+    normalized_content = re.sub(r"<\?xml[^>]*\?>", "", normalized_content).strip()
+    wrapped_content = f"<nfo-root>{normalized_content}</nfo-root>"
+    wrapped_root = ET.fromstring(wrapped_content)
 
-    # Extract all uniqueid elements
+    if not list(wrapped_root):
+        raise ET.ParseError("No XML document found")
+
+    if len(wrapped_root) == 1 and wrapped_root[0].tag == "tvshow":
+        return _extract_tvshow_metadata(wrapped_root[0])
+
+    if all(child.tag == "episodedetails" for child in wrapped_root):
+        return _extract_episode_metadata(wrapped_root)
+
+    if len(wrapped_root) == 1 and wrapped_root[0].tag == "episodedetails":
+        return _extract_episode_metadata(wrapped_root)
+
+    raise ET.ParseError("Unsupported NFO root structure")
+
+
+def _extract_tvshow_metadata(root: ET.Element) -> MetadataInfo:
+    """Extract metadata from a single tvshow document."""
+    info = MetadataInfo(
+        file_type="tvshow",
+        xml_tree=ET.ElementTree(ET.fromstring(ET.tostring(root, encoding="unicode"))),
+    )
+    _populate_common_metadata(info, root)
+    return info
+
+
+def _extract_episode_metadata(root: ET.Element) -> MetadataInfo:
+    """Extract metadata from one or more episode documents."""
+    episode_entries = [_build_episode_entry(child) for child in root]
+    first_entry = episode_entries[0]
+    info = MetadataInfo(
+        tmdb_id=first_entry.tmdb_id,
+        tvdb_id=first_entry.tvdb_id,
+        imdb_id=first_entry.imdb_id,
+        file_type="episodedetails",
+        season=first_entry.season,
+        episode=first_entry.episode,
+        title=first_entry.title,
+        description=first_entry.description,
+        xml_tree=first_entry.xml_tree,
+        episode_entries=episode_entries,
+    )
+
+    for entry in episode_entries[1:]:
+        if info.tmdb_id is None:
+            info.tmdb_id = entry.tmdb_id
+        if info.tvdb_id is None:
+            info.tvdb_id = entry.tvdb_id
+        if info.imdb_id is None:
+            info.imdb_id = entry.imdb_id
+
+    return info
+
+
+def _build_episode_entry(root: ET.Element) -> EpisodeMetadataInfo:
+    """Build a single episode metadata entry from an XML root."""
+    tree = ET.ElementTree(ET.fromstring(ET.tostring(root, encoding="unicode")))
+    entry = EpisodeMetadataInfo(xml_tree=tree)
+    _populate_common_metadata(entry, root)
+
+    season_element = root.find("season")
+    episode_element = root.find("episode")
+    if season_element is not None and season_element.text:
+        entry.season = int(season_element.text.strip())
+    if episode_element is not None and episode_element.text:
+        entry.episode = int(episode_element.text.strip())
+
+    return entry
+
+
+def _populate_common_metadata(
+    info: MetadataInfo | EpisodeMetadataInfo, root: ET.Element
+) -> None:
+    """Populate shared metadata fields from a root element."""
     for uniqueid in root.findall(".//uniqueid"):
         id_type = uniqueid.get("type", "").lower()
         id_value = uniqueid.text
-
         if not id_value or not id_value.strip():
             continue
 
@@ -169,24 +243,10 @@ def extract_metadata_info(nfo_path: Path) -> MetadataInfo:
         elif id_type == "imdb":
             info.imdb_id = id_value.strip()
 
-    # Extract title
     title_element = root.find("title")
     if title_element is not None and title_element.text:
         info.title = title_element.text.strip()
 
-    # Extract plot/description
     plot_element = root.find("plot")
     if plot_element is not None and plot_element.text:
         info.description = plot_element.text.strip()
-
-    # For episode files, extract season/episode numbers
-    if file_type == "episodedetails":
-        season_element = root.find("season")
-        episode_element = root.find("episode")
-
-        if season_element is not None and season_element.text:
-            info.season = int(season_element.text.strip())
-        if episode_element is not None and episode_element.text:
-            info.episode = int(episode_element.text.strip())
-
-    return info

--- a/src/sonarr_metadata_rewrite/file_utils.py
+++ b/src/sonarr_metadata_rewrite/file_utils.py
@@ -213,6 +213,7 @@ def _build_episode_entry(root: ET.Element) -> EpisodeMetadataInfo:
     entry = EpisodeMetadataInfo(xml_tree=tree)
     _populate_common_metadata(entry, root)
 
+    # For episode files, extract season/episode numbers
     season_element = root.find("season")
     episode_element = root.find("episode")
     if season_element is not None and season_element.text:
@@ -227,6 +228,7 @@ def _populate_common_metadata(
     info: MetadataInfo | EpisodeMetadataInfo, root: ET.Element
 ) -> None:
     """Populate shared metadata fields from a root element."""
+    # Extract all uniqueid elements
     for uniqueid in root.findall(".//uniqueid"):
         id_type = uniqueid.get("type", "").lower()
         id_value = uniqueid.text
@@ -240,10 +242,12 @@ def _populate_common_metadata(
         elif id_type == "imdb":
             info.imdb_id = id_value.strip()
 
+    # Extract title
     title_element = root.find("title")
     if title_element is not None and title_element.text:
         info.title = title_element.text.strip()
 
+    # Extract plot/description
     plot_element = root.find("plot")
     if plot_element is not None and plot_element.text:
         info.description = plot_element.text.strip()

--- a/src/sonarr_metadata_rewrite/metadata_processor.py
+++ b/src/sonarr_metadata_rewrite/metadata_processor.py
@@ -9,6 +9,7 @@ from sonarr_metadata_rewrite.backup_utils import create_backup, get_backup_path
 from sonarr_metadata_rewrite.config import Settings
 from sonarr_metadata_rewrite.file_utils import extract_metadata_info
 from sonarr_metadata_rewrite.models import (
+    EpisodeMetadataInfo,
     MetadataInfo,
     MetadataProcessResult,
     TmdbIds,
@@ -39,129 +40,12 @@ class MetadataProcessor:
         tmdb_ids = None
         metadata_info = None
         try:
-            # Extract all metadata in single parse (including content for comparison)
             metadata_info = extract_metadata_info(nfo_path)
 
-            # Build TMDB IDs from parsed metadata using hierarchical resolution
-            tmdb_ids = self._build_tmdb_ids_from_metadata(metadata_info, nfo_path)
-            if not tmdb_ids:
-                return MetadataProcessResult(
-                    success=False,
-                    file_path=nfo_path,
-                    message="No TMDB ID found in .nfo file",
-                    file_modified=False,
-                    translated_content=None,
-                )
+            if metadata_info.file_type == "episodedetails":
+                return self._process_episode_file(nfo_path, metadata_info)
 
-            # Get translations from TMDB API
-            all_translations = self.translator.get_translations(tmdb_ids)
-
-            # Apply language preferences to find best translation
-            selected_translation = self._select_preferred_translation(all_translations)
-
-            if not selected_translation:
-                # No preferred translation found - try to revert to original backup
-                original_metadata = self._get_backup_metadata_info(nfo_path)
-                if original_metadata:
-                    # Only revert if current content is different from original
-                    if (
-                        metadata_info.title != original_metadata.title
-                        or metadata_info.description != original_metadata.description
-                    ):
-                        selected_translation = TranslatedContent(
-                            title=TranslatedString(
-                                content=original_metadata.title, language="original"
-                            ),
-                            description=TranslatedString(
-                                content=original_metadata.description,
-                                language="original",
-                            ),
-                        )
-                        # Continue to write original content back
-                    else:
-                        # Already showing original content
-                        preferred_langs = ", ".join(self.settings.preferred_languages)
-                        available_langs = (
-                            ", ".join(sorted(all_translations.keys()))
-                            if all_translations
-                            else "none"
-                        )
-                        return MetadataProcessResult(
-                            success=False,
-                            file_path=nfo_path,
-                            message=(
-                                f"File unchanged - content already matches original "
-                                f"and "
-                                f"no translation available in preferred languages "
-                                f"[{preferred_langs}]. "
-                                f"Available: [{available_langs}]"
-                            ),
-                            tmdb_ids=tmdb_ids,
-                            file_modified=False,
-                            translated_content=None,
-                        )
-                else:
-                    # No backup available - return existing failure result
-                    preferred_langs = ", ".join(self.settings.preferred_languages)
-                    available_langs = (
-                        ", ".join(sorted(all_translations.keys()))
-                        if all_translations
-                        else "none"
-                    )
-                    return MetadataProcessResult(
-                        success=False,
-                        file_path=nfo_path,
-                        message=(
-                            f"File unchanged - no translation available in preferred "
-                            f"languages [{preferred_langs}]. "
-                            f"Available: [{available_langs}]"
-                        ),
-                        tmdb_ids=tmdb_ids,
-                        file_modified=False,
-                        translated_content=None,
-                    )
-
-            # Apply fallback logic for empty translation fields
-            selected_translation = self._apply_fallback_to_translation(
-                metadata_info, selected_translation
-            )
-
-            # Check if content matches final translation after fallback
-            if (
-                metadata_info.title == selected_translation.title.content
-                and metadata_info.description
-                == selected_translation.description.content
-            ):
-                return MetadataProcessResult(
-                    success=True,
-                    file_path=nfo_path,
-                    message="Content already matches preferred translation",
-                    tmdb_ids=tmdb_ids,
-                    file_modified=False,
-                    translated_content=selected_translation,
-                )
-
-            # Create backup if enabled
-            backup_created = create_backup(
-                nfo_path,
-                self.settings.original_files_backup_dir,
-                self.settings.rewrite_root_dir,
-            )
-
-            # Write translated metadata using cached XML tree
-            self._write_translated_metadata_with_tree(
-                metadata_info.xml_tree, nfo_path, selected_translation
-            )
-
-            return MetadataProcessResult(
-                success=True,
-                file_path=nfo_path,
-                message=self._build_success_message(selected_translation),
-                tmdb_ids=tmdb_ids,
-                backup_created=backup_created,
-                file_modified=True,
-                translated_content=selected_translation,
-            )
+            return self._process_single_metadata_file(nfo_path, metadata_info)
 
         except Exception as e:
             return MetadataProcessResult(
@@ -173,6 +57,254 @@ class MetadataProcessor:
                 file_modified=False,
                 translated_content=None,
             )
+
+    def _process_single_metadata_file(
+        self, nfo_path: Path, metadata_info: MetadataInfo
+    ) -> MetadataProcessResult:
+        """Process a single-document metadata file."""
+        tmdb_ids = None
+
+        # Extract all metadata in single parse (including content for comparison)
+        tmdb_ids = self._build_tmdb_ids_from_metadata(metadata_info, nfo_path)
+        if not tmdb_ids:
+            return MetadataProcessResult(
+                success=False,
+                file_path=nfo_path,
+                message="No TMDB ID found in .nfo file",
+                file_modified=False,
+                translated_content=None,
+            )
+
+        all_translations = self.translator.get_translations(tmdb_ids)
+        selected_translation = self._select_preferred_translation(all_translations)
+
+        if not selected_translation:
+            original_metadata = self._get_backup_metadata_info(nfo_path)
+            if original_metadata:
+                if (
+                    metadata_info.title != original_metadata.title
+                    or metadata_info.description != original_metadata.description
+                ):
+                    selected_translation = TranslatedContent(
+                        title=TranslatedString(
+                            content=original_metadata.title, language="original"
+                        ),
+                        description=TranslatedString(
+                            content=original_metadata.description,
+                            language="original",
+                        ),
+                    )
+                else:
+                    preferred_langs = ", ".join(self.settings.preferred_languages)
+                    available_langs = (
+                        ", ".join(sorted(all_translations.keys()))
+                        if all_translations
+                        else "none"
+                    )
+                    return MetadataProcessResult(
+                        success=False,
+                        file_path=nfo_path,
+                        message=(
+                            f"File unchanged - content already matches original and "
+                            f"no translation available in preferred languages "
+                            f"[{preferred_langs}]. "
+                            f"Available: [{available_langs}]"
+                        ),
+                        tmdb_ids=tmdb_ids,
+                        file_modified=False,
+                        translated_content=None,
+                    )
+            else:
+                preferred_langs = ", ".join(self.settings.preferred_languages)
+                available_langs = (
+                    ", ".join(sorted(all_translations.keys()))
+                    if all_translations
+                    else "none"
+                )
+                return MetadataProcessResult(
+                    success=False,
+                    file_path=nfo_path,
+                    message=(
+                        f"File unchanged - no translation available in preferred "
+                        f"languages [{preferred_langs}]. Available: [{available_langs}]"
+                    ),
+                    tmdb_ids=tmdb_ids,
+                    file_modified=False,
+                    translated_content=None,
+                )
+
+        selected_translation = self._apply_fallback_to_translation(
+            metadata_info, selected_translation
+        )
+
+        if (
+            metadata_info.title == selected_translation.title.content
+            and metadata_info.description == selected_translation.description.content
+        ):
+            return MetadataProcessResult(
+                success=True,
+                file_path=nfo_path,
+                message="Content already matches preferred translation",
+                tmdb_ids=tmdb_ids,
+                file_modified=False,
+                translated_content=selected_translation,
+            )
+
+        backup_created = create_backup(
+            nfo_path,
+            self.settings.original_files_backup_dir,
+            self.settings.rewrite_root_dir,
+        )
+
+        self._write_translated_metadata_with_tree(
+            metadata_info.xml_tree, nfo_path, selected_translation
+        )
+
+        return MetadataProcessResult(
+            success=True,
+            file_path=nfo_path,
+            message=self._build_success_message(selected_translation),
+            tmdb_ids=tmdb_ids,
+            backup_created=backup_created,
+            file_modified=True,
+            translated_content=selected_translation,
+        )
+
+    def _process_episode_file(
+        self, nfo_path: Path, metadata_info: MetadataInfo
+    ) -> MetadataProcessResult:
+        """Process one or more episode documents from a single NFO file."""
+        episode_entries = metadata_info.episode_entries or []
+        series_tmdb_id = self._resolve_tmdb_id_with_metadata(metadata_info, nfo_path)
+        if series_tmdb_id is None:
+            return MetadataProcessResult(
+                success=False,
+                file_path=nfo_path,
+                message="No TMDB ID found in .nfo file",
+                file_modified=False,
+                translated_content=None,
+            )
+
+        selected_translation: TranslatedContent | None = None
+        updated_translations: dict[int, TranslatedContent] = {}
+        translated_count = 0
+        unchanged_count = 0
+        unavailable_count = 0
+        first_tmdb_ids: TmdbIds | None = None
+
+        backup_metadata = self._get_backup_metadata_info(nfo_path)
+
+        for index, entry in enumerate(episode_entries):
+            if entry.season is None or entry.episode is None:
+                unavailable_count += 1
+                continue
+
+            entry_tmdb_ids = TmdbIds(
+                series_id=series_tmdb_id,
+                season=entry.season,
+                episode=entry.episode,
+            )
+            if first_tmdb_ids is None:
+                first_tmdb_ids = entry_tmdb_ids
+
+            all_translations = self.translator.get_translations(entry_tmdb_ids)
+            entry_translation = self._select_preferred_translation(all_translations)
+
+            entry_metadata = self._build_episode_metadata_info(entry, series_tmdb_id)
+            if not entry_translation:
+                backup_entry = self._find_matching_backup_episode(
+                    backup_metadata, entry
+                )
+                if backup_entry and (
+                    entry.title != backup_entry.title
+                    or entry.description != backup_entry.description
+                ):
+                    entry_translation = TranslatedContent(
+                        title=TranslatedString(
+                            content=backup_entry.title, language="original"
+                        ),
+                        description=TranslatedString(
+                            content=backup_entry.description,
+                            language="original",
+                        ),
+                    )
+                else:
+                    unavailable_count += 1
+                    continue
+
+            entry_translation = self._apply_fallback_to_translation(
+                entry_metadata, entry_translation
+            )
+            if selected_translation is None:
+                selected_translation = entry_translation
+
+            if (
+                entry.title == entry_translation.title.content
+                and entry.description == entry_translation.description.content
+            ):
+                unchanged_count += 1
+                translated_count += 1
+                continue
+
+            updated_translations[index] = entry_translation
+            translated_count += 1
+
+        if not updated_translations and translated_count == 0:
+            preferred_langs = ", ".join(self.settings.preferred_languages)
+            return MetadataProcessResult(
+                success=False,
+                file_path=nfo_path,
+                message=(
+                    "File unchanged - no episode translation available in preferred "
+                    f"languages [{preferred_langs}]"
+                ),
+                tmdb_ids=first_tmdb_ids,
+                file_modified=False,
+                translated_content=None,
+            )
+
+        if not updated_translations:
+            message = self._build_multi_episode_message(
+                updated_count=0,
+                translated_count=translated_count,
+                unchanged_count=unchanged_count,
+                unavailable_count=unavailable_count,
+                episode_count=len(episode_entries),
+            )
+            return MetadataProcessResult(
+                success=True,
+                file_path=nfo_path,
+                message=message,
+                tmdb_ids=first_tmdb_ids,
+                file_modified=False,
+                translated_content=selected_translation,
+            )
+
+        backup_created = create_backup(
+            nfo_path,
+            self.settings.original_files_backup_dir,
+            self.settings.rewrite_root_dir,
+        )
+        self._write_translated_episode_entries(
+            episode_entries, nfo_path, updated_translations
+        )
+
+        message = self._build_multi_episode_message(
+            updated_count=len(updated_translations),
+            translated_count=translated_count,
+            unchanged_count=unchanged_count,
+            unavailable_count=unavailable_count,
+            episode_count=len(episode_entries),
+        )
+        return MetadataProcessResult(
+            success=True,
+            file_path=nfo_path,
+            message=message,
+            tmdb_ids=first_tmdb_ids,
+            backup_created=backup_created,
+            file_modified=True,
+            translated_content=selected_translation,
+        )
 
     def _resolve_tmdb_id_with_metadata(
         self, metadata_info: MetadataInfo, nfo_path: Path
@@ -426,6 +558,38 @@ class MetadataProcessor:
 
         return None
 
+    def _build_episode_metadata_info(
+        self, entry: EpisodeMetadataInfo, series_tmdb_id: int
+    ) -> MetadataInfo:
+        """Convert an episode entry into MetadataInfo for shared helpers."""
+        return MetadataInfo(
+            tmdb_id=series_tmdb_id,
+            tvdb_id=entry.tvdb_id,
+            imdb_id=entry.imdb_id,
+            file_type="episodedetails",
+            season=entry.season,
+            episode=entry.episode,
+            title=entry.title,
+            description=entry.description,
+            xml_tree=entry.xml_tree,
+        )
+
+    def _find_matching_backup_episode(
+        self, backup_metadata: MetadataInfo | None, entry: EpisodeMetadataInfo
+    ) -> EpisodeMetadataInfo | None:
+        """Find the matching backup episode by season and episode number."""
+        if backup_metadata is None or not backup_metadata.episode_entries:
+            return None
+
+        for backup_entry in backup_metadata.episode_entries:
+            if (
+                backup_entry.season == entry.season
+                and backup_entry.episode == entry.episode
+            ):
+                return backup_entry
+
+        return None
+
     def _write_translated_metadata_with_tree(
         self,
         xml_tree: ET.ElementTree | None,
@@ -471,6 +635,48 @@ class MetadataProcessor:
 
         except Exception:
             # Clean up temporary file if something went wrong
+            if temp_path.exists():
+                temp_path.unlink()
+            raise
+
+    def _write_translated_episode_entries(
+        self,
+        episode_entries: list[EpisodeMetadataInfo],
+        nfo_path: Path,
+        updated_translations: dict[int, TranslatedContent],
+    ) -> None:
+        """Write translated content for one or more episode XML documents."""
+        temp_path = nfo_path.with_suffix(".nfo.tmp")
+        try:
+            serialized_documents: list[str] = []
+            for index, entry in enumerate(episode_entries):
+                xml_tree = entry.xml_tree
+                if xml_tree is None:
+                    raise ValueError("Episode XML tree cannot be None")
+                root = xml_tree.getroot()
+                if root is None:
+                    raise ValueError("Episode XML root cannot be None")
+
+                translation = updated_translations.get(index)
+                if translation:
+                    title_element = root.find("title")
+                    if title_element is not None:
+                        title_element.text = translation.title.content
+                    plot_element = root.find("plot")
+                    if plot_element is not None:
+                        plot_element.text = translation.description.content
+
+                ET.indent(xml_tree, space="  ", level=0)
+                serialized_documents.append(ET.tostring(root, encoding="unicode"))
+
+            content = (
+                '<?xml version="1.0" encoding="utf-8"?>\n'
+                + "\n".join(serialized_documents)
+                + "\n"
+            )
+            temp_path.write_text(content, encoding="utf-8")
+            temp_path.replace(nfo_path)
+        except Exception:
             if temp_path.exists():
                 temp_path.unlink()
             raise
@@ -535,6 +741,28 @@ class MetadataProcessor:
             if translation.description.content:
                 parts.append(f"description: {translation.description.language}")
             return f"Successfully translated ({', '.join(parts)})"
+
+    def _build_multi_episode_message(
+        self,
+        updated_count: int,
+        translated_count: int,
+        unchanged_count: int,
+        unavailable_count: int,
+        episode_count: int,
+    ) -> str:
+        """Build a status message for multi-episode files."""
+        if episode_count == 1:
+            if updated_count == 1:
+                return "Successfully translated 1 episode"
+            return "Content already matches preferred translation"
+
+        parts = [f"{updated_count} of {episode_count} episodes updated"]
+        if unchanged_count:
+            parts.append(f"{unchanged_count} already matched")
+        skipped_count = episode_count - translated_count
+        if unavailable_count or skipped_count:
+            parts.append(f"{max(unavailable_count, skipped_count)} left unchanged")
+        return "; ".join(parts)
 
     def _get_backup_metadata_info(self, nfo_path: Path) -> MetadataInfo | None:
         """Get original metadata from backup NFO file if available.

--- a/src/sonarr_metadata_rewrite/models.py
+++ b/src/sonarr_metadata_rewrite/models.py
@@ -57,6 +57,21 @@ class MetadataInfo:
 
     # Raw XML for writing
     xml_tree: ET.ElementTree | None = None
+    episode_entries: list["EpisodeMetadataInfo"] | None = None
+
+
+@dataclass
+class EpisodeMetadataInfo:
+    """Episode metadata extracted from an episode NFO document."""
+
+    tmdb_id: int | None = None
+    tvdb_id: int | None = None
+    imdb_id: str | None = None
+    season: int | None = None
+    episode: int | None = None
+    title: str = ""
+    description: str = ""
+    xml_tree: ET.ElementTree | None = None
 
 
 @dataclass

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -122,6 +122,23 @@ SAMPLE_EPISODE_NO_TMDB_ID_NFO = """<?xml version="1.0" encoding="utf-8"?>
 </episodedetails>
 """
 
+SAMPLE_MULTI_EPISODE_NFO = """<?xml version="1.0" encoding="utf-8"?>
+<episodedetails>
+  <title>Pilot</title>
+  <plot>Walter White begins a new life in crime.</plot>
+  <season>1</season>
+  <episode>1</episode>
+  <uniqueid type="tvdb" default="true">349232</uniqueid>
+</episodedetails>
+<episodedetails>
+  <title>Cat's in the Bag...</title>
+  <plot>Walt and Jesse deal with the aftermath.</plot>
+  <season>1</season>
+  <episode>2</episode>
+  <uniqueid type="tvdb" default="true">349233</uniqueid>
+</episodedetails>
+"""
+
 # Map of sample names to content
 SAMPLE_DATA = {
     "tvshow.nfo": SAMPLE_TVSHOW_NFO,
@@ -131,6 +148,7 @@ SAMPLE_DATA = {
     "imdb_only.nfo": SAMPLE_IMDB_ONLY_NFO,
     "invalid.nfo": SAMPLE_INVALID_NFO,
     "episode_no_tmdb_id.nfo": SAMPLE_EPISODE_NO_TMDB_ID_NFO,
+    "multi_episode.nfo": SAMPLE_MULTI_EPISODE_NFO,
 }
 
 

--- a/tests/integration/test_helpers.py
+++ b/tests/integration/test_helpers.py
@@ -355,19 +355,23 @@ def verify_translations(
                 title = entry.get("title", "").strip()
                 plot = entry.get("plot", "").strip()
 
+                # Ensure we have content to detect
                 assert title, f"NFO file {nfo_file} has no title"
                 assert plot, f"NFO file {nfo_file} has no plot"
 
+                # Detect language in title and plot
                 try:
                     title_matches, title_langs = check_language(title)
                     plot_matches, plot_langs = check_language(plot)
 
+                    # Both title and plot must match
                     if not (title_matches and plot_matches):
                         error_parts = [
                             f"Language mismatch in {nfo_file.name}. "
                             f"Expected {expected_language}"
                         ]
 
+                        # Show detection results (only for fields that were detected)
                         if not title_matches and title_langs is not None:
                             error_parts.append(f"title_langs={title_langs}")
                         if not plot_matches and plot_langs is not None:

--- a/tests/integration/test_helpers.py
+++ b/tests/integration/test_helpers.py
@@ -1,7 +1,6 @@
 """Helper functions for integration tests."""
 
 import shutil
-import xml.etree.ElementTree as ET
 from pathlib import Path
 from typing import Any
 
@@ -10,7 +9,11 @@ from fast_langdetect import (  # type: ignore[import-untyped]
     detect_multilingual,
 )
 
-from sonarr_metadata_rewrite.file_utils import find_target_files, is_nfo_file
+from sonarr_metadata_rewrite.file_utils import (
+    extract_metadata_info,
+    find_target_files,
+    is_nfo_file,
+)
 from sonarr_metadata_rewrite.image_utils import read_embedded_marker
 from sonarr_metadata_rewrite.models import ImageCandidate
 from sonarr_metadata_rewrite.retry_utils import retry
@@ -69,6 +72,31 @@ def create_fake_episode_file(
     return episode_file
 
 
+def create_fake_multi_episode_file(
+    media_root: Path,
+    series_slug: str,
+    season: int,
+    first_episode: int,
+    last_episode: int,
+    title: str = "Episode",
+) -> Path:
+    """Create a fake multi-episode video file to trigger Sonarr processing."""
+    series_dir = media_root / series_slug
+    season_dir = series_dir / f"Season {season:02d}"
+    season_dir.mkdir(parents=True, exist_ok=True)
+
+    series_title = series_slug.replace("-", " ").title()
+    filename = (
+        f"{series_title} - S{season:02d}E{first_episode:02d}-E{last_episode:02d}"
+        f" - {title}.mkv"
+    )
+    episode_file = season_dir / filename
+
+    sample_file = Path(__file__).parent / "fixtures" / "sample_episode.mkv"
+    shutil.copy2(sample_file, episode_file)
+    return episode_file
+
+
 def wait_for_nfo_files(
     series_path: Path, expected_count: int, timeout: float = 5.0
 ) -> list[Path]:
@@ -114,42 +142,26 @@ def parse_nfo_content(nfo_path: Path) -> dict[str, Any]:
     Returns:
         Dictionary with parsed metadata
     """
-    tree = ET.parse(nfo_path)
-    root = tree.getroot()
+    extracted = extract_metadata_info(nfo_path)
 
     metadata: dict[str, Any] = {
-        "root_tag": root.tag,
-        "title": "",
-        "plot": "",
-        "tmdb_id": None,
-        "tvdb_id": None,
+        "root_tag": extracted.file_type,
+        "title": extracted.title,
+        "plot": extracted.description,
+        "tmdb_id": extracted.tmdb_id,
+        "tvdb_id": extracted.tvdb_id,
+        "entries": [],
     }
 
-    # Extract title
-    title_elem = root.find("title")
-    if title_elem is not None and title_elem.text:
-        metadata["title"] = title_elem.text.strip()
-
-    # Extract plot/overview
-    plot_elem = root.find("plot")
-    if plot_elem is not None and plot_elem.text:
-        metadata["plot"] = plot_elem.text.strip()
-
-    # Extract IDs
-    for uniqueid in root.findall(".//uniqueid"):
-        id_type = uniqueid.get("type")
-        id_value = uniqueid.text
-
-        if id_type == "tmdb" and id_value:
-            try:
-                metadata["tmdb_id"] = int(id_value.strip())
-            except ValueError:
-                pass
-        elif id_type == "tvdb" and id_value:
-            try:
-                metadata["tvdb_id"] = int(id_value.strip())
-            except ValueError:
-                pass
+    if extracted.episode_entries:
+        metadata["entries"] = [
+            {"title": entry.title, "plot": entry.description}
+            for entry in extracted.episode_entries
+        ]
+    else:
+        metadata["entries"] = [
+            {"title": extracted.title, "plot": extracted.description}
+        ]
 
     return metadata
 
@@ -298,12 +310,6 @@ def verify_translations(
     def check_translation_state() -> None:
         for nfo_file in nfo_files:
             metadata = parse_nfo_content(nfo_file)
-            title = metadata.get("title", "").strip()
-            plot = metadata.get("plot", "").strip()
-
-            # Ensure we have content to detect
-            assert title, f"NFO file {nfo_file} has no title"
-            assert plot, f"NFO file {nfo_file} has no plot"
 
             # Helper function to check if content has exceptions
             def has_exception(content: str) -> bool:
@@ -345,33 +351,37 @@ def verify_translations(
 
                 return threshold_match, detected_langs
 
-            # Detect language in title and plot
-            try:
-                title_matches, title_langs = check_language(title)
-                plot_matches, plot_langs = check_language(plot)
+            for entry in metadata.get("entries", []):
+                title = entry.get("title", "").strip()
+                plot = entry.get("plot", "").strip()
 
-                # Both title and plot must match
-                if not (title_matches and plot_matches):
-                    # Show detection results (only for fields that were detected)
-                    error_parts = [
-                        f"Language mismatch in {nfo_file.name}. "
-                        f"Expected {expected_language}"
-                    ]
+                assert title, f"NFO file {nfo_file} has no title"
+                assert plot, f"NFO file {nfo_file} has no plot"
 
-                    if not title_matches and title_langs is not None:
-                        error_parts.append(f"title_langs={title_langs}")
-                    if not plot_matches and plot_langs is not None:
-                        error_parts.append(f"plot_langs={plot_langs}")
+                try:
+                    title_matches, title_langs = check_language(title)
+                    plot_matches, plot_langs = check_language(plot)
 
-                    error_parts.extend([f"Title: '{title}'", f"Plot: '{plot}'"])
+                    if not (title_matches and plot_matches):
+                        error_parts = [
+                            f"Language mismatch in {nfo_file.name}. "
+                            f"Expected {expected_language}"
+                        ]
 
-                    raise AssertionError(". ".join(error_parts))
+                        if not title_matches and title_langs is not None:
+                            error_parts.append(f"title_langs={title_langs}")
+                        if not plot_matches and plot_langs is not None:
+                            error_parts.append(f"plot_langs={plot_langs}")
 
-            except DetectError as e:
-                raise AssertionError(
-                    f"Language detection failed for {nfo_file}: {e}. "
-                    f"Title: '{title}', Plot: '{plot}'"
-                ) from e
+                        error_parts.extend([f"Title: '{title}'", f"Plot: '{plot}'"])
+
+                        raise AssertionError(". ".join(error_parts))
+
+                except DetectError as e:
+                    raise AssertionError(
+                        f"Language detection failed for {nfo_file}: {e}. "
+                        f"Title: '{title}', Plot: '{plot}'"
+                    ) from e
 
     check_translation_state()
     print(

--- a/tests/integration/test_sonarr_integration.py
+++ b/tests/integration/test_sonarr_integration.py
@@ -4,12 +4,15 @@ from pathlib import Path
 
 import pytest
 
+from tests.integration.fixtures.series_manager import SeriesManager
 from tests.integration.fixtures.sonarr_client import SonarrClient
 from tests.integration.test_helpers import (
     SeriesWithNfos,
     ServiceRunner,
+    create_fake_multi_episode_file,
     verify_images,
     verify_translations,
+    wait_for_nfo_files,
 )
 
 
@@ -245,3 +248,80 @@ def test_advanced_translation_scenarios(
                 expected_language,
                 possible_languages=list(possible_languages),
             )
+
+
+@pytest.mark.integration
+@pytest.mark.slow
+def test_multi_episode_nfo_rewrite_and_rollback(
+    temp_media_root: Path,
+    configured_sonarr_container: SonarrClient,
+    tmp_path: Path,
+) -> None:
+    """Test rewrite and rollback for Sonarr-style multi-episode NFO files."""
+    backup_dir = tmp_path / "multi_episode_backups"
+    backup_dir.mkdir(parents=True, exist_ok=True)
+
+    with SeriesManager(
+        configured_sonarr_container,
+        BREAKING_BAD_TVDB_ID,
+        "/tv",
+        temp_media_root,
+    ) as series:
+        create_fake_multi_episode_file(
+            temp_media_root,
+            series.slug,
+            season=1,
+            first_episode=1,
+            last_episode=2,
+            title="Pilot + Cat's in the Bag",
+        )
+
+        scan_success = configured_sonarr_container.trigger_disk_scan(series.id)
+        assert scan_success, "Failed to trigger disk scan"
+
+        series_path = temp_media_root / series.slug
+        nfo_files = wait_for_nfo_files(series_path, expected_count=2, timeout=30.0)
+        multi_episode_nfos = [
+            nfo_file for nfo_file in nfo_files if "E01-E02" in nfo_file.name
+        ]
+        assert (
+            len(multi_episode_nfos) == 1
+        ), f"Expected one Sonarr-generated multi-episode NFO, got {nfo_files}"
+        multi_episode_nfo = multi_episode_nfos[0]
+
+        original_content = multi_episode_nfo.read_text(encoding="utf-8")
+        assert original_content.count("<episodedetails>") == 2
+        assert "</episodedetails>\n<episodedetails>" in original_content
+
+        with ServiceRunner(
+            temp_media_root,
+            {
+                "ENABLE_FILE_MONITOR": "false",
+                "ORIGINAL_FILES_BACKUP_DIR": str(backup_dir),
+            },
+        ):
+            verify_translations(
+                nfo_files,
+                expected_language="zh",
+                possible_languages=["zh", "en"],
+            )
+            rewritten_content = multi_episode_nfo.read_text(encoding="utf-8")
+            assert rewritten_content.count("<episodedetails>") == 2
+            assert "</episodedetails>\n<episodedetails>" in rewritten_content
+
+        with ServiceRunner(
+            temp_media_root,
+            {
+                "SERVICE_MODE": "rollback",
+                "ENABLE_FILE_MONITOR": "false",
+                "ORIGINAL_FILES_BACKUP_DIR": str(backup_dir),
+            },
+        ):
+            verify_translations(
+                nfo_files,
+                expected_language="en",
+                possible_languages=["zh", "en"],
+            )
+            rolled_back_content = multi_episode_nfo.read_text(encoding="utf-8")
+            assert rolled_back_content.count("<episodedetails>") == 2
+            assert "</episodedetails>\n<episodedetails>" in rolled_back_content

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -6,7 +6,6 @@ from collections.abc import Callable, Generator
 from pathlib import Path
 from typing import Any
 from unittest.mock import patch
-from xml.etree.ElementTree import ElementTree
 
 import pytest
 from diskcache import Cache  # type: ignore[import-untyped]
@@ -14,6 +13,7 @@ from diskcache import Cache  # type: ignore[import-untyped]
 import sonarr_metadata_rewrite.image_processor
 import sonarr_metadata_rewrite.metadata_processor
 from sonarr_metadata_rewrite.config import Settings
+from sonarr_metadata_rewrite.file_utils import _parse_nfo_documents
 from sonarr_metadata_rewrite.retry_utils import retry
 from sonarr_metadata_rewrite.translator import Translator
 
@@ -41,15 +41,15 @@ def patch_time_sleep() -> Generator[None, None, None]:
 def patch_retry_timeout() -> Generator[None, None, None]:
     """Reduce retry timeout for unit tests to speed up failure cases."""
 
-    def fast_parse_nfo_with_retry(nfo_path: Path) -> "ElementTree[ET.Element]":
+    def fast_parse_nfo_with_retry(nfo_path: Path) -> Any:
         @retry(
             timeout=0.1,  # Very short timeout for unit tests
             interval=0.01,  # Very short interval
             log_interval=0.05,
             exceptions=(ET.ParseError, OSError),
         )
-        def parse_file() -> "ElementTree[ET.Element]":
-            return ET.parse(nfo_path)
+        def parse_file() -> Any:
+            return _parse_nfo_documents(nfo_path)
 
         return parse_file()
 

--- a/tests/unit/test_file_utils.py
+++ b/tests/unit/test_file_utils.py
@@ -4,6 +4,7 @@ import tempfile
 from pathlib import Path
 
 from sonarr_metadata_rewrite.file_utils import (
+    extract_metadata_info,
     find_target_files,
     is_nfo_file,
     is_rewritable_image,
@@ -278,3 +279,63 @@ class TestFindRewritableImages:
                 p for p in find_target_files(temp_path) if is_rewritable_image(p)
             ]
             assert found_files == []
+
+
+class TestExtractMetadataInfo:
+    """Test metadata extraction for single and multi-episode NFO files."""
+
+    def test_extract_single_episode_metadata(self, test_data_dir: Path) -> None:
+        nfo_path = test_data_dir / "episode.nfo"
+        nfo_path.write_text(
+            """<?xml version=\"1.0\" encoding=\"utf-8\"?>
+<episodedetails>
+  <title>Pilot</title>
+  <plot>Episode description.</plot>
+  <season>1</season>
+  <episode>1</episode>
+  <uniqueid type=\"tmdb\">1396</uniqueid>
+</episodedetails>
+""",
+            encoding="utf-8",
+        )
+
+        metadata = extract_metadata_info(nfo_path)
+
+        assert metadata.file_type == "episodedetails"
+        assert metadata.season == 1
+        assert metadata.episode == 1
+        assert metadata.title == "Pilot"
+        assert metadata.episode_entries is not None
+        assert len(metadata.episode_entries) == 1
+
+    def test_extract_multi_episode_metadata(self, test_data_dir: Path) -> None:
+        nfo_path = test_data_dir / "multi_episode.nfo"
+        nfo_path.write_text(
+            """<?xml version=\"1.0\" encoding=\"utf-8\"?>
+<episodedetails>
+  <title>Pilot</title>
+  <plot>Walter White begins a new life in crime.</plot>
+  <season>1</season>
+  <episode>1</episode>
+  <uniqueid type=\"tvdb\">349232</uniqueid>
+</episodedetails>
+<episodedetails>
+  <title>Cat's in the Bag...</title>
+  <plot>Walt and Jesse deal with the aftermath.</plot>
+  <season>1</season>
+  <episode>2</episode>
+  <uniqueid type=\"tvdb\">349233</uniqueid>
+</episodedetails>
+""",
+            encoding="utf-8",
+        )
+
+        metadata = extract_metadata_info(nfo_path)
+
+        assert metadata.file_type == "episodedetails"
+        assert metadata.episode_entries is not None
+        assert len(metadata.episode_entries) == 2
+        assert metadata.episode_entries[0].episode == 1
+        assert metadata.episode_entries[0].title == "Pilot"
+        assert metadata.episode_entries[1].episode == 2
+        assert metadata.episode_entries[1].title == "Cat's in the Bag..."

--- a/tests/unit/test_file_utils.py
+++ b/tests/unit/test_file_utils.py
@@ -1,7 +1,10 @@
 """Tests for NFO utility functions."""
 
 import tempfile
+import xml.etree.ElementTree as ET
 from pathlib import Path
+
+import pytest
 
 from sonarr_metadata_rewrite.file_utils import (
     extract_metadata_info,
@@ -339,3 +342,53 @@ class TestExtractMetadataInfo:
         assert metadata.episode_entries[0].title == "Pilot"
         assert metadata.episode_entries[1].episode == 2
         assert metadata.episode_entries[1].title == "Cat's in the Bag..."
+
+    def test_extract_multi_episode_metadata_uses_later_ids_when_first_missing(
+        self, test_data_dir: Path
+    ) -> None:
+        nfo_path = test_data_dir / "multi_episode_missing_ids.nfo"
+        nfo_path.write_text(
+            """<?xml version="1.0" encoding="utf-8"?>
+<episodedetails>
+  <title>Pilot</title>
+  <plot>Episode one.</plot>
+  <season>1</season>
+  <episode>1</episode>
+  <uniqueid type="tmdb">   </uniqueid>
+</episodedetails>
+<episodedetails>
+  <title>Cat's in the Bag...</title>
+  <plot>Episode two.</plot>
+  <season>1</season>
+  <episode>2</episode>
+  <uniqueid type="tvdb">349233</uniqueid>
+  <uniqueid type="imdb">tt0959621</uniqueid>
+</episodedetails>
+""",
+            encoding="utf-8",
+        )
+
+        metadata = extract_metadata_info(nfo_path)
+
+        assert metadata.tvdb_id == 349233
+        assert metadata.imdb_id == "tt0959621"
+        assert metadata.tmdb_id is None
+
+    def test_extract_metadata_info_rejects_unsupported_multi_root_content(
+        self, test_data_dir: Path
+    ) -> None:
+        nfo_path = test_data_dir / "invalid_multi_root.nfo"
+        nfo_path.write_text(
+            """<?xml version="1.0" encoding="utf-8"?>
+<tvshow>
+  <title>Breaking Bad</title>
+</tvshow>
+<episodedetails>
+  <title>Pilot</title>
+</episodedetails>
+""",
+            encoding="utf-8",
+        )
+
+        with pytest.raises(ET.ParseError, match="Unsupported NFO root structure"):
+            extract_metadata_info(nfo_path)

--- a/tests/unit/test_metadata_processor.py
+++ b/tests/unit/test_metadata_processor.py
@@ -11,6 +11,7 @@ from sonarr_metadata_rewrite.config import Settings
 from sonarr_metadata_rewrite.metadata_processor import MetadataProcessor
 from sonarr_metadata_rewrite.models import (
     MetadataInfo,
+    TmdbIds,
     TranslatedContent,
     TranslatedString,
 )
@@ -1371,3 +1372,109 @@ def test_content_matches_after_fallback_skips_processing(
     assert result.translated_content.title.language == "original"  # Fallback language
     assert result.translated_content.description.content == "这是一个示例描述"
     assert result.translated_content.description.language == "zh-CN"  # From translation
+
+
+def test_process_file_multi_episode_partial_update(
+    test_data_dir: Path,
+    create_test_files: Callable[[str, Path], Path],
+) -> None:
+    """Test partial translation updates for multi-episode NFO files."""
+    settings = create_test_settings(test_data_dir)
+    mock_translator = Mock(spec=Translator)
+    processor = MetadataProcessor(settings, mock_translator)
+
+    series_dir = test_data_dir / "Breaking Bad"
+    series_dir.mkdir(parents=True, exist_ok=True)
+    create_test_files("tvshow.nfo", series_dir / "tvshow.nfo")
+    nfo_path = create_test_files("multi_episode.nfo", series_dir / "episodes.nfo")
+
+    def get_translations(tmdb_ids: TmdbIds) -> dict[str, TranslatedContent]:
+        if tmdb_ids.episode == 1:
+            return {
+                "zh-CN": TranslatedContent(
+                    title=TranslatedString(content="试播集", language="zh-CN"),
+                    description=TranslatedString(
+                        content="沃尔特开始了犯罪生涯。", language="zh-CN"
+                    ),
+                )
+            }
+        return {}
+
+    mock_translator.get_translations.side_effect = get_translations
+    mock_translator.find_tmdb_id_by_external_id.return_value = None
+
+    result = processor.process_file(nfo_path)
+
+    assert_process_result(
+        result,
+        expected_success=True,
+        expected_series_id=1396,
+        expected_season=1,
+        expected_episode=1,
+        expected_file_modified=True,
+        expected_language="zh-CN",
+        expected_message_contains="1 of 2 episodes updated",
+    )
+
+    content = nfo_path.read_text(encoding="utf-8")
+    assert "试播集" in content
+    assert "沃尔特开始了犯罪生涯。" in content
+    assert "Cat's in the Bag..." in content
+    assert "Walt and Jesse deal with the aftermath." in content
+
+
+def test_process_file_multi_episode_restore_from_backup_when_translation_missing(
+    test_data_dir: Path,
+    create_test_files: Callable[[str, Path], Path],
+) -> None:
+    """Test multi-episode file restores individual episodes from backup."""
+    settings = create_test_settings(test_data_dir)
+    mock_translator = Mock(spec=Translator)
+    processor = MetadataProcessor(settings, mock_translator)
+
+    series_dir = test_data_dir / "Breaking Bad"
+    backup_dir = test_data_dir / "backups" / "Breaking Bad"
+    series_dir.mkdir(parents=True, exist_ok=True)
+    backup_dir.mkdir(parents=True, exist_ok=True)
+
+    create_test_files("tvshow.nfo", series_dir / "tvshow.nfo")
+    create_test_files("multi_episode.nfo", backup_dir / "episodes.nfo")
+
+    translated_multi_episode = """<?xml version="1.0" encoding="utf-8"?>
+<episodedetails>
+  <title>试播集</title>
+  <plot>沃尔特开始了犯罪生涯。</plot>
+  <season>1</season>
+  <episode>1</episode>
+  <uniqueid type="tvdb" default="true">349232</uniqueid>
+</episodedetails>
+<episodedetails>
+  <title>猫在袋中</title>
+  <plot>沃尔特和杰西处理后果。</plot>
+  <season>1</season>
+  <episode>2</episode>
+  <uniqueid type="tvdb" default="true">349233</uniqueid>
+</episodedetails>
+"""
+    nfo_path = series_dir / "episodes.nfo"
+    nfo_path.write_text(translated_multi_episode, encoding="utf-8")
+
+    mock_translator.get_translations.return_value = {}
+    mock_translator.find_tmdb_id_by_external_id.return_value = None
+
+    result = processor.process_file(nfo_path)
+
+    assert_process_result(
+        result,
+        expected_success=True,
+        expected_series_id=1396,
+        expected_season=1,
+        expected_episode=1,
+        expected_file_modified=True,
+        expected_message_contains="2 of 2 episodes updated",
+    )
+
+    restored_content = nfo_path.read_text(encoding="utf-8")
+    assert "Pilot" in restored_content
+    assert "Cat's in the Bag..." in restored_content
+    assert "试播集" not in restored_content

--- a/tests/unit/test_metadata_processor.py
+++ b/tests/unit/test_metadata_processor.py
@@ -10,6 +10,7 @@ import pytest
 from sonarr_metadata_rewrite.config import Settings
 from sonarr_metadata_rewrite.metadata_processor import MetadataProcessor
 from sonarr_metadata_rewrite.models import (
+    EpisodeMetadataInfo,
     MetadataInfo,
     TmdbIds,
     TranslatedContent,
@@ -1478,3 +1479,192 @@ def test_process_file_multi_episode_restore_from_backup_when_translation_missing
     assert "Pilot" in restored_content
     assert "Cat's in the Bag..." in restored_content
     assert "试播集" not in restored_content
+
+
+def test_process_file_multi_episode_no_translation_available(
+    test_data_dir: Path,
+    create_test_files: Callable[[str, Path], Path],
+) -> None:
+    """Test multi-episode file returns unchanged when no entries are translatable."""
+    settings = create_test_settings(test_data_dir)
+    mock_translator = Mock(spec=Translator)
+    processor = MetadataProcessor(settings, mock_translator)
+
+    series_dir = test_data_dir / "Breaking Bad"
+    backup_dir = test_data_dir / "backups" / "Breaking Bad"
+    series_dir.mkdir(parents=True, exist_ok=True)
+    backup_dir.mkdir(parents=True, exist_ok=True)
+
+    create_test_files("tvshow.nfo", series_dir / "tvshow.nfo")
+    create_test_files("multi_episode.nfo", backup_dir / "episodes.nfo")
+    nfo_path = create_test_files("multi_episode.nfo", series_dir / "episodes.nfo")
+
+    mock_translator.get_translations.return_value = {}
+    mock_translator.find_tmdb_id_by_external_id.return_value = None
+
+    result = processor.process_file(nfo_path)
+
+    assert_process_result(
+        result,
+        expected_success=False,
+        expected_series_id=1396,
+        expected_season=1,
+        expected_episode=1,
+        expected_file_modified=False,
+        expected_message_contains="no episode translation available",
+    )
+
+
+def test_process_file_multi_episode_skips_entry_without_episode_numbers(
+    test_data_dir: Path,
+) -> None:
+    """Test multi-episode processing skips entries missing season or episode."""
+    settings = create_test_settings(test_data_dir)
+    mock_translator = Mock(spec=Translator)
+    processor = MetadataProcessor(settings, mock_translator)
+
+    series_dir = test_data_dir / "Breaking Bad"
+    series_dir.mkdir(parents=True, exist_ok=True)
+    (series_dir / "tvshow.nfo").write_text(
+        """<?xml version="1.0" encoding="utf-8"?>
+<tvshow>
+  <title>Breaking Bad</title>
+  <plot>A chemistry teacher turns to crime.</plot>
+  <uniqueid type="tmdb">1396</uniqueid>
+</tvshow>
+""",
+        encoding="utf-8",
+    )
+    nfo_path = series_dir / "episodes.nfo"
+    nfo_path.write_text(
+        """<?xml version="1.0" encoding="utf-8"?>
+<episodedetails>
+  <title>Pilot</title>
+  <plot>Walter White begins a new life in crime.</plot>
+  <season>1</season>
+  <episode>1</episode>
+</episodedetails>
+<episodedetails>
+  <title>Broken Entry</title>
+  <plot>Missing episode number.</plot>
+</episodedetails>
+""",
+        encoding="utf-8",
+    )
+
+    mock_translator.get_translations.return_value = {
+        "zh-CN": TranslatedContent(
+            title=TranslatedString(content="试播集", language="zh-CN"),
+            description=TranslatedString(
+                content="沃尔特开始了犯罪生涯。", language="zh-CN"
+            ),
+        )
+    }
+    mock_translator.find_tmdb_id_by_external_id.return_value = None
+
+    result = processor.process_file(nfo_path)
+
+    assert_process_result(
+        result,
+        expected_success=True,
+        expected_series_id=1396,
+        expected_season=1,
+        expected_episode=1,
+        expected_file_modified=True,
+        expected_message_contains="1 left unchanged",
+    )
+
+
+def test_process_file_multi_episode_reports_already_matched_entries(
+    test_data_dir: Path,
+    create_test_files: Callable[[str, Path], Path],
+) -> None:
+    """Test multi-episode message includes already matched entries."""
+    settings = create_test_settings(test_data_dir)
+    mock_translator = Mock(spec=Translator)
+    processor = MetadataProcessor(settings, mock_translator)
+
+    series_dir = test_data_dir / "Breaking Bad"
+    series_dir.mkdir(parents=True, exist_ok=True)
+    create_test_files("tvshow.nfo", series_dir / "tvshow.nfo")
+    nfo_path = series_dir / "episodes.nfo"
+    nfo_path.write_text(
+        """<?xml version="1.0" encoding="utf-8"?>
+<episodedetails>
+  <title>试播集</title>
+  <plot>沃尔特开始了犯罪生涯。</plot>
+  <season>1</season>
+  <episode>1</episode>
+</episodedetails>
+<episodedetails>
+  <title>Cat's in the Bag...</title>
+  <plot>Walt and Jesse deal with the aftermath.</plot>
+  <season>1</season>
+  <episode>2</episode>
+</episodedetails>
+""",
+        encoding="utf-8",
+    )
+
+    def get_translations(tmdb_ids: TmdbIds) -> dict[str, TranslatedContent]:
+        if tmdb_ids.episode == 1:
+            return {
+                "zh-CN": TranslatedContent(
+                    title=TranslatedString(content="试播集", language="zh-CN"),
+                    description=TranslatedString(
+                        content="沃尔特开始了犯罪生涯。", language="zh-CN"
+                    ),
+                )
+            }
+        return {
+            "zh-CN": TranslatedContent(
+                title=TranslatedString(content="袋中猫", language="zh-CN"),
+                description=TranslatedString(
+                    content="两人处理善后。", language="zh-CN"
+                ),
+            )
+        }
+
+    mock_translator.get_translations.side_effect = get_translations
+    mock_translator.find_tmdb_id_by_external_id.return_value = None
+
+    result = processor.process_file(nfo_path)
+
+    assert_process_result(
+        result,
+        expected_success=True,
+        expected_series_id=1396,
+        expected_season=1,
+        expected_episode=1,
+        expected_file_modified=True,
+        expected_message_contains="1 already matched",
+    )
+
+
+def test_write_translated_metadata_with_tree_requires_xml_tree(
+    processor: MetadataProcessor,
+    test_data_dir: Path,
+) -> None:
+    """Test single-document writer rejects missing XML trees."""
+    with pytest.raises(ValueError, match="XML tree cannot be None"):
+        processor._write_translated_metadata_with_tree(
+            None,
+            test_data_dir / "out.nfo",
+            TranslatedContent(
+                title=TranslatedString(content="Title", language="en"),
+                description=TranslatedString(content="Plot", language="en"),
+            ),
+        )
+
+
+def test_write_translated_episode_entries_requires_xml_tree(
+    processor: MetadataProcessor,
+    test_data_dir: Path,
+) -> None:
+    """Test multi-document writer rejects missing XML trees."""
+    with pytest.raises(ValueError, match="Episode XML tree cannot be None"):
+        processor._write_translated_episode_entries(
+            [EpisodeMetadataInfo()],
+            test_data_dir / "out.nfo",
+            {},
+        )

--- a/tests/unit/test_rollback_service.py
+++ b/tests/unit/test_rollback_service.py
@@ -499,3 +499,66 @@ def test_execute_rollback_with_no_backup_files(test_data_dir: Path) -> None:
 
     # Should not raise
     service.execute_rollback()
+
+
+def test_execute_rollback_restores_multi_episode_nfo(test_data_dir: Path) -> None:
+    """Test rollback restores Sonarr-style multi-episode NFO content."""
+    backup_dir = test_data_dir / "backups"
+    original_dir = test_data_dir / "media"
+    backup_dir.mkdir(parents=True, exist_ok=True)
+    original_dir.mkdir(parents=True, exist_ok=True)
+
+    backup_file = backup_dir / "Breaking Bad" / "Season 01" / "episodes.nfo"
+    backup_file.parent.mkdir(parents=True, exist_ok=True)
+    backup_file.write_text(
+        """<?xml version="1.0" encoding="utf-8"?>
+<episodedetails>
+  <title>Pilot</title>
+  <plot>Walter White begins a new life in crime.</plot>
+  <season>1</season>
+  <episode>1</episode>
+</episodedetails>
+<episodedetails>
+  <title>Cat's in the Bag...</title>
+  <plot>Walt and Jesse deal with the aftermath.</plot>
+  <season>1</season>
+  <episode>2</episode>
+</episodedetails>
+""",
+        encoding="utf-8",
+    )
+
+    original_file = original_dir / "Breaking Bad" / "Season 01" / "episodes.nfo"
+    original_file.parent.mkdir(parents=True, exist_ok=True)
+    original_file.write_text(
+        """<?xml version="1.0" encoding="utf-8"?>
+<episodedetails>
+  <title>试播集</title>
+  <plot>沃尔特开始了犯罪生涯。</plot>
+  <season>1</season>
+  <episode>1</episode>
+</episodedetails>
+<episodedetails>
+  <title>猫在袋中</title>
+  <plot>沃尔特和杰西处理后果。</plot>
+  <season>1</season>
+  <episode>2</episode>
+</episodedetails>
+""",
+        encoding="utf-8",
+    )
+
+    settings = create_test_settings(
+        test_data_dir,
+        service_mode="rollback",
+        rewrite_root_dir=original_dir,
+        original_files_backup_dir=backup_dir,
+    )
+    service = RollbackService(settings)
+
+    service.execute_rollback()
+
+    restored_content = original_file.read_text(encoding="utf-8")
+    assert "Pilot" in restored_content
+    assert "Cat's in the Bag..." in restored_content
+    assert "试播集" not in restored_content


### PR DESCRIPTION
## Summary
- add multi-episode NFO parsing and per-episode rewrite handling for Sonarr files that contain adjacent `<episodedetails>` roots
- preserve Sonarr's multi-root XML format during rewrite and rollback, including partial updates when only some episodes have translations
- add unit and integration coverage for parsing, rewrite, rollback, and verification of Sonarr-generated multi-root metadata

## Issues
- Closes #54
- Closes #76

## Validation
- `uv run pytest tests/unit/test_file_utils.py tests/unit/test_metadata_processor.py tests/unit/test_rollback_service.py`
- `uv run pytest tests/integration/test_sonarr_integration.py -k multi_episode_nfo_rewrite_and_rollback`
- `uv run ruff check src tests`