### PR TITLE
[feat] add Radarr movie support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,8 +4,8 @@ This file provides guidance for AI agents working with code in this repository.
 
 ## Project Overview
 
-Sonarr Metadata Rewrite - A compatibility layer that monitors
-Sonarr-generated .nfo files and overwrites them with TMDB translations in
+Sonarr Metadata Rewrite - A compatibility layer that monitors Sonarr- and
+Radarr-generated .nfo files and overwrites them with TMDB translations in
 desired languages, and rewrites poster/clearlogo images to language-specific
 variants when available. This addresses [Sonarr Issue #269](
 https://github.com/Sonarr/Sonarr/issues/269) (multilingual metadata) and
@@ -60,7 +60,7 @@ uv run sonarr-metadata-rewrite
 uv run sonarr-metadata-rewrite --version
 
 # Run with custom settings for testing
-REWRITE_ROOT_DIR=/tmp/test/media \
+REWRITE_ROOT_DIRS=/tmp/test/tv,/tmp/test/movies \
 PREFERRED_LANGUAGES='zh-CN,ja-JP' \
 CACHE_DURATION_HOURS=1 \
 uv run sonarr-metadata-rewrite
@@ -70,7 +70,8 @@ uv run sonarr-metadata-rewrite
 
 ### Current Implementation
 
-Metadata translation and image rewrite service with Click framework providing:
+Sonarr TV and Radarr movie metadata translation and image rewrite service with
+Click framework providing:
 
 - Entry point: `sonarr_metadata_rewrite.main:cli` command that runs a
   persistent service (CLI: `sonarr-metadata-rewrite`)
@@ -105,10 +106,10 @@ backup creation.
 
 1. **Translator** (`translator.py`)
 TMDB API client using httpx with diskcache-backed caching and exponential
-backoff for HTTP 429. Supports series and episode translations. For images,
-fetches `/tv/{id}/images` or `/tv/{id}/season/{s}/images`, filters locally for
-preferred language-country (e.g., `en-US`) and chooses the first exact match;
-does not pass `include_image_language` due to TMDB API issues.
+backoff for HTTP 429. Supports TV series, TV episode, and movie translations.
+For images, fetches TV, TV season, or movie image resources, filters locally
+for preferred language-country (e.g., `en-US`) and chooses the first exact
+match; does not pass `include_image_language` due to TMDB API issues.
 
 1. **FileMonitor** (`file_monitor.py`)
 Real-time file system monitoring using watchdog. Processes .nfo and image files
@@ -121,9 +122,10 @@ scanning with graceful shutdown.
 
 1. **Configuration** (`config.py`)
 Pydantic Settings-based configuration with custom env source parsing
-`PREFERRED_LANGUAGES` as a comma-separated string (not JSON) into `list[str]`.
-Includes `ENABLE_IMAGE_REWRITE` flag (default: true). Loads from .env and
-performs comprehensive validation.
+`PREFERRED_LANGUAGES` and `REWRITE_ROOT_DIRS` as comma-separated strings (not
+JSON) into lists. `REWRITE_ROOT_DIR` remains supported as a single-root legacy
+setting. Includes independent NFO and image rewrite flags. Loads from `.env`
+and performs comprehensive validation.
 
 1. **ImageProcessor** (`image_processor.py`)
 Complete image rewrite workflow: identify rewritable image files (poster,
@@ -153,10 +155,11 @@ Retry logic with exponential backoff for handling transient failures, particular
 for TMDB API rate limiting (HTTP 429) responses.
 
 1. **Data Models** (`models.py`)
-TmdbIds: TMDB identifier structures for series/episodes. TranslatedContent:
-Translated metadata containers. ProcessResult: base outcome. MetadataProcessResult:
-NFO-specific. ImageCandidate: TMDB image candidate (file_path, iso_639_1,
-iso_3166_1). ImageProcessResult: image-specific outcome.
+TmdbIds: media-aware TMDB identifier structures for TV series/episodes and
+movies; `media_type` is required and movies cannot include season or episode.
+TranslatedContent: translated metadata containers. ProcessResult: base outcome.
+MetadataProcessResult: NFO-specific. ImageCandidate: TMDB image candidate
+(file_path, iso_639_1, iso_3166_1). ImageProcessResult: image-specific outcome.
 
 1. **Version Management** (`_version.py`)
 Hatch-generated version file from VCS tags with dynamic version handling and
@@ -164,9 +167,11 @@ development fallback.
 
 ### TMDB API Integration Design
 
-- **Text endpoints**: `/tv/{series_id}/translations` and
-  `/tv/{series_id}/season/{season_number}/episode/{episode_number}/translations`
-- **Image endpoints**: `/tv/{series_id}/images` and `/tv/{series_id}/season/{season_number}/images`
+- **Text endpoints**: `/tv/{series_id}/translations`,
+  `/tv/{series_id}/season/{season_number}/episode/{episode_number}/translations`,
+  and `/movie/{movie_id}/translations`
+- **Image endpoints**: `/tv/{series_id}/images`,
+  `/tv/{series_id}/season/{season_number}/images`, and `/movie/{movie_id}/images`
   - Don't pass `include_image_language`; fetch all and filter client-side in
     code due to TMDB API quirk
 - **Rate Limits**: TMDB has rate limits, and explicit rate limiting with
@@ -185,8 +190,8 @@ development fallback.
   module boundaries (including `_version`)
 - **Testing**: pytest with coverage, separate unit/integration test
   directories with shared container infrastructure
-- **Integration Testing**: Docker-based Sonarr integration with comprehensive
-  test scenarios
+- **Integration Testing**: Docker/Podman-based Sonarr and Radarr integration
+  tests
 - **Dead Code**: Vulture with whitelist support
 - **Automation**: pre-commit hooks for all quality checks
 
@@ -212,8 +217,8 @@ src/sonarr_metadata_rewrite/
 └── retry_utils.py (retry logic with exponential backoff)
 tests/
 ├── unit/ (fast unit tests for all modules)
-├── integration/ (comprehensive Sonarr integration tests with Docker)
-│   └── fixtures/ (container management, series management, subprocess service)
+├── integration/ (Sonarr and Radarr integration tests with Docker/Podman)
+│   └── fixtures/ (container clients, media managers, subprocess service)
 └── conftest.py (shared test fixtures)
 scripts/ (development automation)
 ```
@@ -240,9 +245,9 @@ scripts/ (development automation)
 - **TMDB Rate Limits**: TMDB has rate limits, and explicit rate limiting with
   exponential backoff retry is implemented - the service automatically retries
   rate-limited requests with configurable delays
-- **File Format**: Sonarr generates XML .nfo files with TMDB IDs
-- **Target Files**: `tvshow.nfo` (series), episode-specific .nfo files, and
-  image files matching the patterns above
+- **File Format**: Sonarr and Radarr generate XML `.nfo` files with TMDB IDs
+- **Target Files**: TV show, episode, and movie `.nfo` files, plus image files
+  matching the patterns above
 - **Service Architecture**: Long-running daemon process with graceful
   shutdown support
 - **Reprocessing Avoidance**: Implemented to prevent unnecessary API calls and

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,28 @@
+# Media Metadata Rewrite
+
+This service localizes Sonarr TV and Radarr movie metadata plus selected local
+artwork using TMDB resources.
+
+## Language
+
+**Target Root NFO**:
+An NFO whose XML root is `<tvshow>` or `<movie>` and can identify media for
+image processing.
+_Avoid_: Any NFO, parent NFO
+
+**Episode NFO**:
+An NFO rooted at `<episodedetails>` that contains metadata for one or more TV
+episodes.
+_Avoid_: Season NFO
+
+**Movie NFO**:
+An NFO rooted at `<movie>` describing one Radarr-managed movie.
+_Avoid_: Video NFO
+
+**Media Type**:
+The TMDB resource family, either TV or movie.
+_Avoid_: Source application
+
+**Artwork Kind**:
+The local artwork category selected for rewriting: poster or clearlogo.
+_Avoid_: Image type

--- a/README.md
+++ b/README.md
@@ -3,13 +3,19 @@
 ![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/kfstorm/2eafe27677e3a2ebbda29cbd026ff32b/raw/coverage.json)
 [![CI](https://github.com/kfstorm/sonarr-metadata-rewrite/actions/workflows/ci.yml/badge.svg)](https://github.com/kfstorm/sonarr-metadata-rewrite/actions/workflows/ci.yml)
 
-Ever been frustrated that Sonarr only gives you English metadata for your TV
-shows? This tool fixes that by watching for Sonarr's `.nfo` files and
-automatically replacing them with translations in whatever language you prefer.
-It can also rewrite poster and clearlogo images to language-specific variants
-when available (e.g., `poster.jpg`, `clearlogo.png`, `season01-poster.jpg`).
+Sonarr only generates English metadata. Radarr can generate movie metadata in
+one configured language, but it cannot make artwork follow that language and
+does not support an ordered language fallback. This tool watches Sonarr TV and
+Radarr movie `.nfo` files, then applies your preferred language list in order.
+It rewrites poster and clearlogo images to language-specific variants when
+available (e.g., `poster.jpg`, `clearlogo.png`, `season01-poster.jpg`).
 
-It's my solution to [Sonarr Issue #269](
+The same Radarr artwork gap is described in [localized poster issue #9863](
+https://github.com/Radarr/Radarr/issues/9863), [translated images issue #5277](
+https://github.com/Radarr/Radarr/issues/5277), and [metadata artwork language
+issue #8025](https://github.com/Radarr/Radarr/issues/8025).
+
+It also addresses [Sonarr Issue #269](
 https://github.com/Sonarr/Sonarr/issues/269) and
 [Sonarr Issue #6663](https://github.com/Sonarr/Sonarr/issues/6663)
 . It turns out a lot of people want
@@ -20,17 +26,20 @@ natively.
 
 The tool runs as a background service that:
 
-- Watches your media folders for when Sonarr creates or updates `.nfo` files
+- Watches your media folders for when Sonarr or Radarr creates or updates `.nfo`
+  files
 - Grabs the TMDB ID from those files and fetches translations from TMDB's API
-- Replaces the English metadata with your preferred language(s)
+- Applies preferred languages in order, falling back when a title, plot, or
+  image is unavailable in a higher-priority language
 - Rewrites poster and clearlogo images based on your preferred language-country
   codes (e.g., `en-US`, `ja-JP`) when such variants exist on TMDB
 - Does this fast enough that you barely notice it happening
 - Keeps backups of the original files in case you want them back
 - Caches everything so it doesn't spam TMDB's API
 
-You can configure multiple languages with fallback priority - like Chinese
-first, then Japanese, then just leave it in English if neither is available.
+You can configure multiple languages with fallback priority, such as Chinese
+first and Japanese second. Metadata fields may use different fallback languages
+when TMDB has only a title or plot in the higher-priority language.
 
 ## Installation
 
@@ -93,7 +102,8 @@ volumes:
 
 ```bash
 TMDB_API_KEY=your_api_read_access_token_here  # Your TMDB API Read Access Token
-# One or more media directories (comma-separated) to watch for Sonarr .nfo files
+# One or more media directories (comma-separated) to watch for
+# Sonarr/Radarr NFO files
 REWRITE_ROOT_DIRS=/tv,/anime
 # Comma-separated language codes in priority order
 PREFERRED_LANGUAGES=zh-CN,ja-JP
@@ -155,9 +165,14 @@ order.
 
 If image rewriting is enabled, the service recognizes these filenames:
 
-- Series-level: `poster.*`, `clearlogo.*`
+- TV series-level: `poster.*`, `clearlogo.*`
 - Season-level: `seasonNN-poster.*` (e.g., `season01-poster.jpg`)
 - Specials: `season-specials-poster.*`
+- Movie-level: `poster.*`, `clearlogo.*`
+
+Current Radarr Kodi/Emby metadata generation creates movie posters but not
+clearlogos. Existing `clearlogo.*` files in movie directories are still
+rewritten when a matching TMDB image is available.
 
 Supported extensions: `.jpg`, `.jpeg`, `.png`.
 
@@ -241,7 +256,7 @@ docker logs sonarr-metadata-rewrite
 You'll see something like:
 
 ```text
-🚀 Starting Sonarr Metadata Rewrite...
+🚀 Starting Sonarr and Radarr Metadata Rewrite...
 ✅ TMDB API key loaded (ending in ...xyz)
 📁 Monitoring directory: /tv
 📁 Monitoring directory: /anime
@@ -249,8 +264,8 @@ You'll see something like:
 ✅ Service started successfully
 ```
 
-The container runs in the background. When Sonarr updates your shows, this
-will automatically translate the metadata files.
+The container runs in the background. When Sonarr updates TV shows or Radarr
+updates movies, it automatically translates their metadata files.
 
 To stop the container:
 
@@ -265,7 +280,7 @@ The service has a few main parts:
 **File monitoring** - Uses Python's `watchdog` to watch for file changes
 (.nfo and image files) in real-time
 
-**TMDB integration** - Extracts TMDB IDs from Sonarr's XML files and
+**TMDB integration** - Extracts TMDB IDs from Sonarr and Radarr XML files and
 fetches translations via their API
 
 **Smart caching** - Stores translations locally so it doesn't hit the API
@@ -282,7 +297,7 @@ about it.
 
 ## Restoring originals (rollback)
 
-If you want to restore Sonarr's original English metadata (and images), you can
+If you want to restore Sonarr or Radarr original English metadata (and images),
 use the built-in rollback functionality to automatically restore all original
 files from backups.
 

--- a/docs/design/radarr-movie-support.md
+++ b/docs/design/radarr-movie-support.md
@@ -15,7 +15,7 @@ naming mode:
 - `movie.nfo`
 - `<VideoFileName>.nfo`
 
-Movie artwork support is limited to Radarr's generated short names:
+Movie artwork support is limited to Radarr's recognized short names:
 
 - `poster.*`
 - `clearlogo.*`
@@ -30,8 +30,9 @@ Supported extensions remain `.jpg`, `.jpeg`, and `.png`.
 - Radarr writes `movie.nfo` when `UseMovieNfo` is enabled. Otherwise it writes
   `<VideoFileName>.nfo`.
 - Radarr's current Kodi/Emby metadata provider generates short artwork names.
-  It can generate `poster.*` and `clearlogo.*` when the movie metadata has
-  those image types.
+  In current Radarr releases, TMDB-provided movie covers generate `poster.*`
+  and `fanart.*`; they do not generate `clearlogo.*`. The service still
+  rewrites an existing movie `clearlogo.*` from another artwork source.
 - Sonarr's Kodi/Emby metadata uses `<tvshow>` for series metadata and
   `<episodedetails>` for episode metadata. Sonarr does not generate season NFO
   files. Season artwork is identified by its filename and uses the parent TV
@@ -158,12 +159,13 @@ Every scenario verifies all of the following:
 
 - Radarr produced the selected NFO naming mode and a `<movie>` document.
 - Movie `<title>` and `<plot>` were rewritten to the preferred language.
-- Radarr-produced `poster.*` and `clearlogo.*` received markers for the
-  expected localized TMDB candidates.
+- Radarr-produced `poster.*` received a marker for the expected localized TMDB
+  candidate.
 
-The test movie fixture must have Radarr Clearlogo metadata and TMDB localized
-poster and clearlogo candidates for the configured language. Missing upstream
-data fails the test rather than skipping it.
+Movie `clearlogo.*` rewriting is covered by unit tests because Radarr does not
+currently generate that file from its TMDB metadata. The integration fixture
+must have a localized TMDB poster candidate for the configured language.
+Missing upstream data fails the test rather than skipping it.
 
 Unit tests cover NFO parsing, media-aware paths and endpoints, movie title
 parsing, original-title fallback, movie image resolution, ambiguous root-NFO

--- a/docs/design/radarr-movie-support.md
+++ b/docs/design/radarr-movie-support.md
@@ -1,0 +1,249 @@
+# Radarr Movie Support Design
+
+## Status
+
+Accepted design. Implementation has not started.
+
+## Goal
+
+Extend the service to rewrite Radarr Kodi/Emby movie metadata and localized
+movie artwork while preserving existing Sonarr TV behavior.
+
+The service must support Radarr-generated movie NFO files in either supported
+naming mode:
+
+- `movie.nfo`
+- `<VideoFileName>.nfo`
+
+Movie artwork support is limited to Radarr's generated short names:
+
+- `poster.*`
+- `clearlogo.*`
+
+Supported extensions remain `.jpg`, `.jpeg`, and `.png`.
+
+## Sources and Constraints
+
+- Radarr's Kodi/Emby metadata root is `<movie>`.
+- Radarr requires each managed movie to have its own directory. A flat
+  multi-movie directory is not a supported Radarr library layout.
+- Radarr writes `movie.nfo` when `UseMovieNfo` is enabled. Otherwise it writes
+  `<VideoFileName>.nfo`.
+- Radarr's current Kodi/Emby metadata provider generates short artwork names.
+  It can generate `poster.*` and `clearlogo.*` when the movie metadata has
+  those image types.
+- Sonarr's Kodi/Emby metadata uses `<tvshow>` for series metadata and
+  `<episodedetails>` for episode metadata. Sonarr does not generate season NFO
+  files. Season artwork is identified by its filename and uses the parent TV
+  show ID.
+- Radarr movie NFO files are expected to contain a TMDB ID. Movie processing
+  does not resolve missing TMDB IDs through IMDb or TVDB.
+
+## Domain Model
+
+`TmdbIds` becomes media-aware:
+
+- `tmdb_id`: TMDB resource ID.
+- `media_type`: `tv` or `movie`.
+- `season` and `episode`: TV-only optional fields.
+
+Resource paths:
+
+| Media | Resource path |
+| --- | --- |
+| TV show | `tv/{tmdb_id}` |
+| TV episode | `tv/{tmdb_id}/season/{season}/episode/{episode}` |
+| Movie | `movie/{tmdb_id}` |
+
+Movie identifiers must not contain season or episode values.
+
+## Metadata Processing
+
+All NFO files remain eligible for metadata processing. The XML root controls
+the processing branch:
+
+| Root | Behavior |
+| --- | --- |
+| `<tvshow>` | Existing series title and plot rewrite. |
+| `<episodedetails>` | Episode rewrite; supports multi-episode NFO. |
+| `<movie>` | New movie title and plot rewrite. |
+| Other | Unsupported NFO result. |
+
+Movie rewriting updates only `<title>` and `<plot>`. It must preserve
+`<originaltitle>`, `<sorttitle>`, all identifiers, ratings, watched state, and
+all other Radarr-generated XML.
+
+For a movie NFO without a TMDB ID, processing stops without an external ID
+lookup. This relies on Radarr's guaranteed TMDB ID and avoids matching a movie
+to an incorrect TMDB resource.
+
+Episode processing retains parent-series ID lookup. When an episode needs a
+parent series ID, search at most three ancestor directories. At each directory,
+inspect NFO contents and select a unique `<tvshow>` root NFO. Ignore movie,
+episode, and unknown roots. No matching TV show continues the search; multiple
+TV show roots make resolution fail.
+
+Existing backup, original-content restoration, language fallback, atomic write,
+and reprocessing-avoidance behavior applies to movies without changes.
+
+## Translator Behavior
+
+TV requests remain unchanged. Movie requests use TMDB movie resources:
+
+| Operation | TV | Movie |
+| --- | --- | --- |
+| Translations | `/tv/{id}/translations` | `/movie/{id}/translations` |
+| Original details | `/tv/{id}` | `/movie/{id}` |
+| Images | `/tv/{id}/images` | `/movie/{id}/images` |
+
+Translation parsing uses `data.name` for TV and `data.title` for movies. Both
+use `data.overview` for plots. Original-title fallback uses `original_name` for
+TV and `original_title` for movies.
+
+The existing TV external-ID lookup remains TV-only. Movie processing does not
+call it because a Radarr movie without a TMDB ID is skipped.
+
+Image selection continues to fetch all image candidates and filter locally by
+exact language-country preference order. It does not add
+`include_image_language`, matching existing project behavior for TMDB image API
+compatibility.
+
+## Image Processing
+
+Image handling uses one shared flow:
+
+1. Parse a supported filename and determine artwork kind plus optional TV
+   season number.
+2. Inspect all NFO files in the image directory.
+3. Keep only NFO files rooted at `<tvshow>` or `<movie>`; ignore
+   `<episodedetails>` and unsupported roots.
+4. Require exactly one retained root NFO. Zero or multiple candidates return a
+   failure result and make no TMDB request or file write.
+5. Use that root NFO's media type and TMDB ID to select an image.
+6. Reuse existing marker comparison, backup creation/restoration, download,
+   extension normalization, and atomic image write behavior.
+
+This allows a Sonarr TV root directory to contain `tvshow.nfo` plus episode
+NFO files without making series or season artwork ambiguous.
+
+TV image behavior remains:
+
+- `poster.*` and `clearlogo.*` use series images.
+- `seasonNN-poster.*` and `season-specials-poster.*` use season images.
+- Image NFO resolution is limited to the image directory. It does not search
+  ancestors.
+
+Movie image behavior:
+
+- `poster.*` and `clearlogo.*` use movie images.
+- Season poster filenames with a movie NFO are rejected.
+- Long movie artwork names such as `<VideoFileName>-poster.*` and
+  `<VideoFileName>-clearlogo.*` are ignored. Radarr currently recognizes such
+  files but does not generate them through its Kodi/Emby metadata provider.
+
+## Integration Test Design
+
+Integration tests use a real Radarr container and real Radarr-generated NFO
+and image files. Only the video file may be a test fixture. NFO files and
+images must not be mocked or hand-authored.
+
+The test matrix has four scenarios:
+
+| NFO mode | File monitor | Periodic scanner |
+| --- | --- | --- |
+| `movie.nfo` | Test | Test |
+| `<VideoFileName>.nfo` | Test | Test |
+
+Every scenario verifies all of the following:
+
+- Radarr produced the selected NFO naming mode and a `<movie>` document.
+- Movie `<title>` and `<plot>` were rewritten to the preferred language.
+- Radarr-produced `poster.*` and `clearlogo.*` received markers for the
+  expected localized TMDB candidates.
+
+The test movie fixture must have Radarr Clearlogo metadata and TMDB localized
+poster and clearlogo candidates for the configured language. Missing upstream
+data fails the test rather than skipping it.
+
+Unit tests cover NFO parsing, media-aware paths and endpoints, movie title
+parsing, original-title fallback, movie image resolution, ambiguous root-NFO
+rejection, and all existing TV/episode behavior affected by the shared flow.
+
+TDD is deliberately not required. Implementation order is production code,
+unit tests, integration tests, then full verification.
+
+## Verification
+
+Run:
+
+```bash
+./scripts/run-unit-tests.sh
+./scripts/run-integration-tests.sh
+./scripts/combine-coverage.sh
+./scripts/lint.sh --check
+```
+
+The baseline combined coverage measured before this work is 95%. Combined
+coverage must not decrease.
+
+## Rejected or Superseded Options
+
+### Image-only Radarr support
+
+Rejected. The goal includes movie metadata, and Radarr's `<movie>` NFO contains
+the title and plot fields that require localized rewriting.
+
+### Require specific NFO filenames for image association
+
+Rejected. Radarr supports two NFO naming modes. Image association therefore
+uses parsed root content rather than `movie.nfo` or a video-derived name.
+
+### Reject an image directory whenever it has multiple NFO files
+
+Rejected. A valid Sonarr TV root can contain `tvshow.nfo` plus episode NFO
+files when season folders are disabled. Only multiple target roots
+(`<tvshow>`/`<movie>`) are ambiguous; episode and unrelated NFO files are
+ignored for image association.
+
+### Apply movie-only NFO rules to all TV metadata
+
+Rejected. TV requires `<episodedetails>` processing for episode title and plot
+translation. TV metadata processing must continue to handle series and
+episode roots independently.
+
+### Add season title and plot translation
+
+Rejected. Sonarr and Kodi do not define or generate a season NFO for this
+workflow. Season localization remains artwork-only.
+
+### Support long Radarr artwork names
+
+Rejected. Current Radarr Kodi/Emby metadata generation produces short names.
+Long-name support would require synthetic integration fixtures and would not
+validate Radarr's actual output.
+
+### Support a flat multi-movie Radarr directory
+
+Rejected. Radarr requires a distinct directory for each managed movie. Flat
+movie directory behavior is outside supported Radarr operation.
+
+### Resolve movie IDs through IMDb or TVDB
+
+Rejected. Radarr movie NFO files are expected to have a TMDB ID. Skipping a
+missing ID is safer than resolving a potentially wrong movie.
+
+### Treat duplicate `movie.nfo` and video-named movie NFO files as equivalent
+
+Rejected. More than one target root NFO in an image directory is treated as
+ambiguous even when IDs match. This keeps image ownership deterministic.
+
+### Use TDD as an implementation constraint
+
+Rejected. TDD was explicitly removed from the task. Tests remain mandatory,
+but production code may be written before tests.
+
+### Rename the package or CLI
+
+Rejected. The package, CLI, and Docker image remain
+`sonarr-metadata-rewrite` to avoid breaking existing users. Documentation and
+runtime text should state that Radarr is supported.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "sonarr-metadata-rewrite"
 dynamic = ["version"]
-description = "Compatibility layer that overwrites Sonarr-generated metadata files with TMDB translations"
+description = "Compatibility layer that localizes Sonarr and Radarr metadata files with TMDB translations"
 license = {text = "MIT"}
 authors = [{name = "Kai Yang", email = "kfstorm@outlook.com"}]
 keywords = ["sonarr", "tmdb", "metadata", "translation", "nfo", "automation"]

--- a/src/sonarr_metadata_rewrite/__init__.py
+++ b/src/sonarr_metadata_rewrite/__init__.py
@@ -1,7 +1,7 @@
-"""Sonarr Metadata Rewrite.
+"""Sonarr and Radarr Metadata Rewrite.
 
-A compatibility layer that monitors Sonarr-generated .nfo files and overwrites
-them with TMDB translations in desired languages.
+A compatibility layer that monitors Sonarr TV and Radarr movie metadata files
+and localizes them with TMDB translations in desired languages.
 """
 
 try:

--- a/src/sonarr_metadata_rewrite/file_utils.py
+++ b/src/sonarr_metadata_rewrite/file_utils.py
@@ -179,8 +179,12 @@ def _parse_nfo_documents(nfo_path: Path) -> MetadataInfo:
     if not list(wrapped_root):
         raise ET.ParseError("No XML document found")
 
-    if len(wrapped_root) == 1 and wrapped_root[0].tag == "tvshow":
-        return _extract_tvshow_metadata(wrapped_root[0])
+    if len(wrapped_root) == 1:
+        root = wrapped_root[0]
+        if root.tag == "tvshow":
+            return _extract_tvshow_metadata(root)
+        if root.tag == "movie":
+            return _extract_movie_metadata(root)
 
     if all(child.tag == "episodedetails" for child in wrapped_root):
         return _extract_episode_metadata(wrapped_root)
@@ -192,6 +196,16 @@ def _extract_tvshow_metadata(root: ET.Element) -> MetadataInfo:
     """Extract metadata from a single tvshow document."""
     info = MetadataInfo(
         file_type="tvshow",
+        xml_tree=ET.ElementTree(ET.fromstring(ET.tostring(root, encoding="unicode"))),
+    )
+    _populate_common_metadata(info, root)
+    return info
+
+
+def _extract_movie_metadata(root: ET.Element) -> MetadataInfo:
+    """Extract metadata from a single movie document."""
+    info = MetadataInfo(
+        file_type="movie",
         xml_tree=ET.ElementTree(ET.fromstring(ET.tostring(root, encoding="unicode"))),
     )
     _populate_common_metadata(info, root)

--- a/src/sonarr_metadata_rewrite/image_processor.py
+++ b/src/sonarr_metadata_rewrite/image_processor.py
@@ -1,6 +1,7 @@
 """Image processor for rewriting poster and clearlogo images."""
 
 import logging
+import xml.etree.ElementTree as ET
 from pathlib import Path
 
 import httpx
@@ -14,6 +15,7 @@ from sonarr_metadata_rewrite.config import Settings
 from sonarr_metadata_rewrite.file_utils import (
     IMAGE_EXTENSIONS,
     extract_metadata_info,
+    is_nfo_file,
     parse_image_info,
 )
 from sonarr_metadata_rewrite.image_utils import (
@@ -196,36 +198,46 @@ class ImageProcessor:
         @retry(timeout=5.0, interval=1.0, exceptions=(FileNotFoundError,))
         def _find_and_extract_tmdb_id() -> TmdbIds:
             """
-            Find and extract TMDB ID from tvshow.nfo file.
-            This function locates the tvshow.nfo file that is always
-            placed next to the image file
-            (as per Kodi's NFO file structure: https://kodi.wiki/view/NFO_files/TV_shows),
-            extracts the TMDB ID from it, and returns a TmdbIds object
-            containing the series ID and season number.
+            Find one target root NFO next to image and extract its TMDB ID.
 
             Returns:
-                TmdbIds: An object containing the TMDB series ID and season number.
+                TmdbIds: An object containing media ID and optional TV season number.
 
             Raises:
-                FileNotFoundError: If tvshow.nfo is not found next to the image file.
-                ValueError: If TMDB ID could not be extracted from the tvshow.nfo file.
+                FileNotFoundError: If no target root NFO is next to the image file.
+                ValueError: If roots are ambiguous or missing a TMDB ID.
             """
-            # tvshow.nfo is always next to the image file
-            nfo_path = image_path.parent / "tvshow.nfo"
-            if not nfo_path.exists():
+            metadata_candidates = []
+            for nfo_path in image_path.parent.iterdir():
+                if not nfo_path.is_file() or not is_nfo_file(nfo_path):
+                    continue
+                try:
+                    metadata_info = extract_metadata_info(nfo_path)
+                except (ET.ParseError, OSError, ValueError):
+                    continue
+                if metadata_info.file_type in {"tvshow", "movie"}:
+                    metadata_candidates.append(metadata_info)
+
+            if not metadata_candidates:
                 raise FileNotFoundError(
-                    f"Could not find tvshow.nfo for image: {image_path}"
+                    f"Could not find target root NFO for image: {image_path}"
                 )
+            if len(metadata_candidates) != 1:
+                raise ValueError(f"Ambiguous target root NFOs for image: {image_path}")
 
-            metadata_info = extract_metadata_info(nfo_path)
+            metadata_info = metadata_candidates[0]
             if not metadata_info.tmdb_id:
-                raise ValueError(f"Could not extract TMDB ID from {nfo_path}")
+                raise ValueError(f"Could not extract TMDB ID for image: {image_path}")
+            if metadata_info.file_type == "movie":
+                if season_num is not None:
+                    raise ValueError("Movie artwork cannot be season-specific")
+                return TmdbIds(tmdb_id=metadata_info.tmdb_id, media_type="movie")
 
-            return TmdbIds(series_id=metadata_info.tmdb_id, season=season_num)
+            return TmdbIds(tmdb_id=metadata_info.tmdb_id, season=season_num)
 
         try:
             return _find_and_extract_tmdb_id()
-        except FileNotFoundError:
+        except (FileNotFoundError, ValueError):
             return None
 
     def _download_and_write_image(

--- a/src/sonarr_metadata_rewrite/image_processor.py
+++ b/src/sonarr_metadata_rewrite/image_processor.py
@@ -233,7 +233,9 @@ class ImageProcessor:
                     raise ValueError("Movie artwork cannot be season-specific")
                 return TmdbIds(tmdb_id=metadata_info.tmdb_id, media_type="movie")
 
-            return TmdbIds(tmdb_id=metadata_info.tmdb_id, season=season_num)
+            return TmdbIds(
+                tmdb_id=metadata_info.tmdb_id, media_type="tv", season=season_num
+            )
 
         try:
             return _find_and_extract_tmdb_id()

--- a/src/sonarr_metadata_rewrite/main.py
+++ b/src/sonarr_metadata_rewrite/main.py
@@ -25,10 +25,10 @@ logger = logging.getLogger(__name__)
 @click.command()
 @click.version_option(version=__version__)
 def cli() -> None:
-    """Sonarr Metadata Rewrite.
+    """Sonarr and Radarr Metadata Rewrite.
 
-    A long-running service that monitors Sonarr-generated .nfo files and
-    overwrites them with TMDB translations in your desired language.
+    A long-running service that monitors Sonarr TV and Radarr movie metadata
+    files and localizes them with TMDB translations in your desired language.
 
     In rollback mode, restores original files from backups and hangs.
     """
@@ -39,7 +39,7 @@ def cli() -> None:
         click.echo(f"❌ {e}", err=True)
         sys.exit(1)
 
-    click.echo("🚀 Starting Sonarr Metadata Rewrite...")
+    click.echo("🚀 Starting Sonarr and Radarr Metadata Rewrite...")
     click.echo(f"✅ TMDB API key loaded (ending in ...{settings.tmdb_api_key[-4:]})")
     for root_dir in settings.rewrite_root_dirs:
         click.echo(f"📁 Monitoring directory: {root_dir}")

--- a/src/sonarr_metadata_rewrite/metadata_processor.py
+++ b/src/sonarr_metadata_rewrite/metadata_processor.py
@@ -201,6 +201,7 @@ class MetadataProcessor:
 
             entry_tmdb_ids = TmdbIds(
                 tmdb_id=series_tmdb_id,
+                media_type="tv",
                 season=entry.season,
                 episode=entry.episode,
             )
@@ -448,7 +449,7 @@ class MetadataProcessor:
 
         # Build TmdbIds based on file type
         if metadata_info.file_type == "tvshow":
-            return TmdbIds(tmdb_id=tmdb_series_id)
+            return TmdbIds(tmdb_id=tmdb_series_id, media_type="tv")
         elif metadata_info.file_type == "movie":
             return TmdbIds(tmdb_id=tmdb_series_id, media_type="movie")
         elif metadata_info.file_type == "episodedetails":
@@ -457,6 +458,7 @@ class MetadataProcessor:
                 return None
             return TmdbIds(
                 tmdb_id=tmdb_series_id,
+                media_type="tv",
                 season=metadata_info.season,
                 episode=metadata_info.episode,
             )

--- a/src/sonarr_metadata_rewrite/metadata_processor.py
+++ b/src/sonarr_metadata_rewrite/metadata_processor.py
@@ -7,7 +7,7 @@ from xml.etree.ElementTree import ElementTree  # noqa: F401
 
 from sonarr_metadata_rewrite.backup_utils import create_backup, get_backup_path
 from sonarr_metadata_rewrite.config import Settings
-from sonarr_metadata_rewrite.file_utils import extract_metadata_info
+from sonarr_metadata_rewrite.file_utils import extract_metadata_info, is_nfo_file
 from sonarr_metadata_rewrite.models import (
     EpisodeMetadataInfo,
     MetadataInfo,
@@ -200,7 +200,7 @@ class MetadataProcessor:
                 continue
 
             entry_tmdb_ids = TmdbIds(
-                series_id=series_tmdb_id,
+                tmdb_id=series_tmdb_id,
                 season=entry.season,
                 episode=entry.episode,
             )
@@ -318,6 +318,11 @@ class MetadataProcessor:
         Returns:
             TMDB series ID if found, None otherwise
         """
+        # Movies must have a direct TMDB ID; TV external-ID resolution does not
+        # identify movie resources safely.
+        if metadata_info.file_type == "movie":
+            return metadata_info.tmdb_id
+
         # Tier 1: Direct TMDB ID (already checked in metadata_info)
         if metadata_info.tmdb_id:
             return metadata_info.tmdb_id
@@ -333,7 +338,7 @@ class MetadataProcessor:
         return self._resolve_via_external_apis(metadata_info, parent_info)
 
     def _find_parent_metadata_info(self, episode_nfo_path: Path) -> MetadataInfo | None:
-        """Find and parse parent tvshow.nfo file for episode.
+        """Find a unique parent TV show NFO for an episode.
 
         Args:
             episode_nfo_path: Path to episode .nfo file
@@ -343,18 +348,23 @@ class MetadataProcessor:
         """
         current_dir = episode_nfo_path.parent
 
-        # Check up to 3 levels up to find tvshow.nfo
+        # Check up to 3 levels up. A series root can use a nonstandard NFO name.
         for _ in range(3):
-            tvshow_path = current_dir / "tvshow.nfo"
-            if tvshow_path.exists() and tvshow_path.is_file():
+            candidates: list[MetadataInfo] = []
+            for nfo_path in current_dir.iterdir():
+                if not nfo_path.is_file() or not is_nfo_file(nfo_path):
+                    continue
                 try:
-                    # Parse and extract metadata info
-                    metadata_info = extract_metadata_info(tvshow_path)
+                    metadata_info = extract_metadata_info(nfo_path)
                     if metadata_info.file_type == "tvshow":
-                        return metadata_info
+                        candidates.append(metadata_info)
                 except (ET.ParseError, ValueError, AttributeError):
-                    # Failed to parse, continue searching
-                    pass
+                    continue
+
+            if len(candidates) == 1:
+                return candidates[0]
+            if len(candidates) > 1:
+                return None
 
             # Move up one directory level
             parent_dir = current_dir.parent
@@ -438,13 +448,15 @@ class MetadataProcessor:
 
         # Build TmdbIds based on file type
         if metadata_info.file_type == "tvshow":
-            return TmdbIds(series_id=tmdb_series_id)
+            return TmdbIds(tmdb_id=tmdb_series_id)
+        elif metadata_info.file_type == "movie":
+            return TmdbIds(tmdb_id=tmdb_series_id, media_type="movie")
         elif metadata_info.file_type == "episodedetails":
             if metadata_info.season is None or metadata_info.episode is None:
                 # Missing season/episode information
                 return None
             return TmdbIds(
-                series_id=tmdb_series_id,
+                tmdb_id=tmdb_series_id,
                 season=metadata_info.season,
                 episode=metadata_info.episode,
             )
@@ -533,7 +545,8 @@ class MetadataProcessor:
 
             # Build TmdbIds object for API call
             tmdb_ids = TmdbIds(
-                series_id=metadata_info.tmdb_id,
+                tmdb_id=metadata_info.tmdb_id,
+                media_type="movie" if metadata_info.file_type == "movie" else "tv",
                 season=metadata_info.season,
                 episode=metadata_info.episode,
             )

--- a/src/sonarr_metadata_rewrite/models.py
+++ b/src/sonarr_metadata_rewrite/models.py
@@ -3,22 +3,34 @@
 import xml.etree.ElementTree as ET
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Literal
 
 
 @dataclass
 class TmdbIds:
     """TMDB identifiers extracted from .nfo files."""
 
-    series_id: int
-    season: int | None = None  # None for tvshow.nfo
-    episode: int | None = None  # None for tvshow.nfo
+    tmdb_id: int
+    media_type: Literal["tv", "movie"] = "tv"
+    season: int | None = None
+    episode: int | None = None
+
+    def __post_init__(self) -> None:
+        """Reject invalid media and episode combinations."""
+        if self.media_type == "movie" and (
+            self.season is not None or self.episode is not None
+        ):
+            raise ValueError("Movie TMDB IDs cannot include season or episode")
+        if self.episode is not None and self.season is None:
+            raise ValueError("TV episode TMDB IDs require a season")
 
     def __str__(self) -> str:
         """Return TMDB resource path."""
+        if self.media_type == "movie":
+            return f"movie/{self.tmdb_id}"
         if self.season is not None and self.episode is not None:
-            return f"tv/{self.series_id}/season/{self.season}/episode/{self.episode}"
-        else:
-            return f"tv/{self.series_id}"
+            return f"tv/{self.tmdb_id}/season/{self.season}/episode/{self.episode}"
+        return f"tv/{self.tmdb_id}"
 
 
 @dataclass
@@ -47,7 +59,7 @@ class MetadataInfo:
     imdb_id: str | None = None
 
     # File structure
-    file_type: str = "unknown"  # "tvshow" or "episodedetails" or "unknown"
+    file_type: str = "unknown"  # "tvshow", "movie", "episodedetails", or "unknown"
     season: int | None = None
     episode: int | None = None
 

--- a/src/sonarr_metadata_rewrite/models.py
+++ b/src/sonarr_metadata_rewrite/models.py
@@ -11,7 +11,7 @@ class TmdbIds:
     """TMDB identifiers extracted from .nfo files."""
 
     tmdb_id: int
-    media_type: Literal["tv", "movie"] = "tv"
+    media_type: Literal["tv", "movie"]
     season: int | None = None
     episode: int | None = None
 

--- a/src/sonarr_metadata_rewrite/rewrite_service.py
+++ b/src/sonarr_metadata_rewrite/rewrite_service.py
@@ -39,7 +39,7 @@ class RewriteService:
 
     def start(self) -> None:
         """Start file monitoring and scanning services."""
-        logger.info("Starting Sonarr Metadata Rewrite Service")
+        logger.info("Starting Sonarr and Radarr Metadata Rewrite Service")
         for root_dir in self.settings.rewrite_root_dirs:
             logger.info(f"Monitoring directory: {root_dir}")
         logger.info(f"Preferred languages: {self.settings.preferred_languages}")
@@ -61,7 +61,7 @@ class RewriteService:
 
     def stop(self) -> None:
         """Stop the service and cleanup all resources."""
-        logger.info("Stopping Sonarr Metadata Rewrite Service")
+        logger.info("Stopping Sonarr and Radarr Metadata Rewrite Service")
 
         # Stop monitoring and scanning (only if they were started)
         if self.settings.enable_file_monitor:

--- a/src/sonarr_metadata_rewrite/translator.py
+++ b/src/sonarr_metadata_rewrite/translator.py
@@ -31,10 +31,10 @@ class Translator:
         )
 
     def get_translations(self, tmdb_ids: TmdbIds) -> dict[str, TranslatedContent]:
-        """Get all translations for TV series or episode.
+        """Get all translations for TV, episode, or movie resources.
 
         Args:
-            tmdb_ids: TMDB identifiers containing series_id and optional season/episode
+            tmdb_ids: TMDB identifiers containing media type and optional TV episode
 
         Returns:
             Dictionary mapping language codes to TranslatedContent objects
@@ -44,7 +44,7 @@ class Translator:
         def fetch_translations() -> dict[str, TranslatedContent]:
             endpoint = f"/{tmdb_ids}/translations"
             api_data = self._fetch_with_retry(endpoint)
-            return self._parse_api_translations(api_data)
+            return self._parse_api_translations(api_data, tmdb_ids.media_type)
 
         translations = self._get_with_cache(
             cache_key, fetch_translations, default_on_404={}
@@ -128,7 +128,7 @@ class Translator:
             raise
 
     def _parse_api_translations(
-        self, api_data: dict[str, Any]
+        self, api_data: dict[str, Any], media_type: str
     ) -> dict[str, TranslatedContent]:
         """Parse TMDB API response into TranslatedContent objects."""
         translations = {}
@@ -147,7 +147,8 @@ class Translator:
                 f"{language_code}-{country_code}" if country_code else language_code
             )
 
-            title = data.get("name", "").strip()
+            title_key = "title" if media_type == "movie" else "name"
+            title = data.get(title_key, "").strip()
             description = data.get("overview", "").strip()
 
             # Skip if both title and description are empty
@@ -164,10 +165,10 @@ class Translator:
         return translations
 
     def get_original_details(self, tmdb_ids: TmdbIds) -> tuple[str, str] | None:
-        """Get original language and title for TV series or episode.
+        """Get original language and title for TV, episode, or movie resources.
 
         Args:
-            tmdb_ids: TMDB identifiers containing series_id and optional season/episode
+            tmdb_ids: TMDB identifiers containing media type and optional TV episode
 
         Returns:
             Tuple of (original_language, original_title) if found, None otherwise
@@ -176,23 +177,27 @@ class Translator:
 
         def fetch_details() -> tuple[str, str] | None:
             # For episodes, we need both episode name and series original language
-            if tmdb_ids.season is not None and tmdb_ids.episode is not None:
+            if tmdb_ids.media_type == "movie":
+                api_data = self._fetch_with_retry(f"/movie/{tmdb_ids.tmdb_id}")
+                original_language = api_data.get("original_language", "")
+                original_title = api_data.get("original_title", "")
+            elif tmdb_ids.season is not None and tmdb_ids.episode is not None:
                 # Get episode details for the name
                 episode_endpoint = (
-                    f"/tv/{tmdb_ids.series_id}/season/{tmdb_ids.season}"
+                    f"/tv/{tmdb_ids.tmdb_id}/season/{tmdb_ids.season}"
                     f"/episode/{tmdb_ids.episode}"
                 )
                 episode_data = self._fetch_with_retry(episode_endpoint)
 
                 # Get series details for the original language
-                series_endpoint = f"/tv/{tmdb_ids.series_id}"
+                series_endpoint = f"/tv/{tmdb_ids.tmdb_id}"
                 series_data = self._fetch_with_retry(series_endpoint)
 
                 original_language = series_data.get("original_language", "")
                 original_title = episode_data.get("name", "")
             else:
                 # Series details endpoint
-                endpoint = f"/tv/{tmdb_ids.series_id}"
+                endpoint = f"/tv/{tmdb_ids.tmdb_id}"
                 api_data = self._fetch_with_retry(endpoint)
 
                 original_language = api_data.get("original_language", "")
@@ -283,7 +288,7 @@ class Translator:
         """Select the best image candidate based on language preferences.
 
         Args:
-            tmdb_ids: TMDB identifiers (series_id and optional season)
+            tmdb_ids: TMDB identifiers (media type and optional TV season)
             preferred_languages: List of language codes in preference order
                 (e.g., ["en-US", "ja-JP"])
             kind: Image kind - "poster" or "clearlogo"
@@ -293,9 +298,9 @@ class Translator:
         """
         # Determine endpoint based on kind and season
         if kind == "poster" and tmdb_ids.season is not None:
-            endpoint = f"/tv/{tmdb_ids.series_id}/season/{tmdb_ids.season}/images"
+            endpoint = f"/tv/{tmdb_ids.tmdb_id}/season/{tmdb_ids.season}/images"
         else:
-            endpoint = f"/tv/{tmdb_ids.series_id}/images"
+            endpoint = f"/{tmdb_ids.media_type}/{tmdb_ids.tmdb_id}/images"
 
         # Fetch images from TMDB
         # NOTE: Do NOT pass include_image_language due to TMDB API bug;

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -65,6 +65,27 @@ SAMPLE_EPISODE_NFO = """<?xml version="1.0" encoding="utf-8"?>
 </episodedetails>
 """  # noqa: E501
 
+SAMPLE_MOVIE_NFO = """<?xml version="1.0" encoding="utf-8"?>
+<movie>
+  <title>Original Movie</title>
+  <originaltitle>Original Movie Title</originaltitle>
+  <sorttitle>Movie, Original</sorttitle>
+  <plot>Original movie plot.</plot>
+  <uniqueid type="tmdb" default="true">550</uniqueid>
+  <uniqueid type="imdb">tt0137523</uniqueid>
+  <rating>8.4</rating>
+  <watched>false</watched>
+</movie>
+"""
+
+SAMPLE_MOVIE_NO_TMDB_ID_NFO = """<?xml version="1.0" encoding="utf-8"?>
+<movie>
+  <title>Movie Without TMDB ID</title>
+  <plot>This movie only has an IMDb ID.</plot>
+  <uniqueid type="imdb" default="true">tt0137523</uniqueid>
+</movie>
+"""
+
 SAMPLE_NO_TMDB_ID_NFO = """<?xml version="1.0" encoding="utf-8"?>
 <tvshow>
   <title>Series Without TMDB ID</title>
@@ -143,6 +164,8 @@ SAMPLE_MULTI_EPISODE_NFO = """<?xml version="1.0" encoding="utf-8"?>
 SAMPLE_DATA = {
     "tvshow.nfo": SAMPLE_TVSHOW_NFO,
     "episode.nfo": SAMPLE_EPISODE_NFO,
+    "movie.nfo": SAMPLE_MOVIE_NFO,
+    "movie_no_tmdb_id.nfo": SAMPLE_MOVIE_NO_TMDB_ID_NFO,
     "no_tmdb_id.nfo": SAMPLE_NO_TMDB_ID_NFO,
     "tvdb_only.nfo": SAMPLE_TVDB_ONLY_NFO,
     "imdb_only.nfo": SAMPLE_IMDB_ONLY_NFO,
@@ -224,7 +247,7 @@ def callback_tracker() -> Mock:
 def assert_process_result(
     result: MetadataProcessResult,
     expected_success: bool,
-    expected_series_id: int | None = None,
+    expected_tmdb_id: int | None = None,
     expected_season: int | None = None,
     expected_episode: int | None = None,
     expected_file_modified: bool | None = None,
@@ -234,9 +257,9 @@ def assert_process_result(
     """Shared assertion helper for MetadataProcessResult validation."""
     assert result.success == expected_success
 
-    if expected_series_id is not None:
+    if expected_tmdb_id is not None:
         assert result.tmdb_ids is not None
-        assert result.tmdb_ids.series_id == expected_series_id
+        assert result.tmdb_ids.tmdb_id == expected_tmdb_id
 
     if expected_season is not None:
         assert result.tmdb_ids is not None

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -9,10 +9,31 @@ from pathlib import Path
 import pytest
 
 from tests.integration.fixtures.container_manager import ContainerManager
+from tests.integration.fixtures.radarr_client import RadarrClient
 from tests.integration.fixtures.sonarr_client import SonarrClient
 
 # Test API key used for integration tests
 TEST_API_KEY = "testkey12345678901234567890"
+
+
+def _write_arr_config(config_dir: Path, port: int, instance_name: str) -> None:
+    """Write common LinuxServer Arr config."""
+    (config_dir / "config.xml").write_text(f"""<?xml version="1.0" encoding="utf-8"?>
+<Config>
+  <Port>{port}</Port>
+  <SslPort>9898</SslPort>
+  <EnableSsl>False</EnableSsl>
+  <LaunchBrowser>False</LaunchBrowser>
+  <AuthenticationMethod>None</AuthenticationMethod>
+  <AuthenticationRequired>DisabledForLocalAddresses</AuthenticationRequired>
+  <Branch>main</Branch>
+  <ApiKey>{TEST_API_KEY}</ApiKey>
+  <SslCertPath></SslCertPath>
+  <SslCertPassword></SslCertPassword>
+  <UrlBase></UrlBase>
+  <UpdateMechanism>Docker</UpdateMechanism>
+  <InstanceName>{instance_name}</InstanceName>
+</Config>""")
 
 
 @pytest.fixture(scope="session")
@@ -28,24 +49,11 @@ def temp_config_dir() -> Generator[Path, None, None]:
     with tempfile.TemporaryDirectory(prefix="sonarr_config_") as temp_dir:
         temp_path = Path(temp_dir)
 
-        # Create config.xml inside the directory
-        config_file = temp_path / "config.xml"
-        config_file.write_text(f"""<?xml version="1.0" encoding="utf-8"?>
-<Config>
-  <Port>8989</Port>
-  <SslPort>9898</SslPort>
-  <EnableSsl>False</EnableSsl>
-  <LaunchBrowser>False</LaunchBrowser>
-  <AuthenticationMethod>None</AuthenticationMethod>
-  <AuthenticationRequired>DisabledForLocalAddresses</AuthenticationRequired>
-  <Branch>main</Branch>
-  <ApiKey>{TEST_API_KEY}</ApiKey>
-  <SslCertPath></SslCertPath>
-  <SslCertPassword></SslCertPassword>
-  <UrlBase></UrlBase>
-  <UpdateMechanism>Docker</UpdateMechanism>
-  <InstanceName>Sonarr (Test)</InstanceName>
-</Config>""")
+        _write_arr_config(
+            temp_path,
+            port=8989,
+            instance_name="Sonarr (Test)",
+        )
         yield temp_path
 
 
@@ -123,3 +131,49 @@ def configured_sonarr_container(sonarr_container: SonarrClient) -> SonarrClient:
         raise RuntimeError("Failed to configure metadata settings")
     print("Metadata settings configured successfully")
     return sonarr_container
+
+
+@pytest.fixture(scope="session")
+def temp_radarr_config_dir() -> Generator[Path, None, None]:
+    """Create temporary config directory for Radarr container."""
+    with tempfile.TemporaryDirectory(prefix="radarr_config_") as temp_dir:
+        temp_path = Path(temp_dir)
+        _write_arr_config(temp_path, port=7878, instance_name="Radarr (Test)")
+        yield temp_path
+
+
+@pytest.fixture(scope="session")
+def radarr_container(
+    temp_media_root: Path,
+    temp_radarr_config_dir: Path,
+) -> Generator[RadarrClient, None, None]:
+    """Start Radarr container and return configured client."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("", 0))
+        free_port = sock.getsockname()[1]
+
+    with ContainerManager() as manager:
+        extra_args = ["--userns=keep-id"] if manager.runtime == "podman" else []
+        manager.run_container(
+            image="docker.io/linuxserver/radarr:latest",
+            name=f"radarr-test-{free_port}",
+            ports={7878: free_port},
+            volumes={
+                str(temp_media_root): "/movies",
+                str(temp_radarr_config_dir): "/config",
+            },
+            environment={
+                "TZ": "UTC",
+                "PUID": str(os.getuid()),
+                "PGID": str(os.getgid()),
+            },
+            extra_args=extra_args,
+        )
+        client = RadarrClient(f"http://localhost:{free_port}", api_key=TEST_API_KEY)
+        if not client.wait_for_ready(max_attempts=30, delay=1.0):
+            raise RuntimeError("Radarr failed to become ready within 30 seconds")
+        manager.start_streaming()
+        try:
+            yield client
+        finally:
+            client.close()

--- a/tests/integration/fixtures/arr_client.py
+++ b/tests/integration/fixtures/arr_client.py
@@ -1,0 +1,27 @@
+"""Shared HTTP client support for Arr integration fixtures."""
+
+from typing import Any
+
+import httpx
+
+
+class ArrClient:
+    """Authenticated HTTP client shared by Sonarr and Radarr test fixtures."""
+
+    def __init__(self, base_url: str, api_key: str | None = None):
+        self.base_url = base_url.rstrip("/")
+        self.api_key = api_key
+        self.client = httpx.Client(timeout=30.0)
+
+    def _make_request(
+        self, method: str, endpoint: str, **kwargs: Any
+    ) -> httpx.Response:
+        """Make a request with the configured API key."""
+        if self.api_key:
+            params = kwargs.setdefault("params", {})
+            params["apikey"] = self.api_key
+        return self.client.request(method, f"{self.base_url}{endpoint}", **kwargs)
+
+    def close(self) -> None:
+        """Close the HTTP client."""
+        self.client.close()

--- a/tests/integration/fixtures/movie_manager.py
+++ b/tests/integration/fixtures/movie_manager.py
@@ -1,0 +1,73 @@
+"""Movie lifecycle management for integration tests."""
+
+from pathlib import Path
+from types import TracebackType
+from typing import Any
+
+from tests.integration.fixtures.radarr_client import RadarrClient
+
+
+class MovieManager:
+    """Context manager for Radarr movie lifecycle in tests."""
+
+    def __init__(
+        self,
+        radarr_client: RadarrClient,
+        tmdb_id: int,
+        root_folder: str,
+        temp_media_root: Path,
+        quality_profile_id: int = 1,
+    ):
+        self.radarr_client = radarr_client
+        self.tmdb_id = tmdb_id
+        self.root_folder = root_folder
+        self.temp_media_root = temp_media_root
+        self.quality_profile_id = quality_profile_id
+        self.movie_data: dict[str, Any] | None = None
+
+    def __enter__(self) -> "MovieManager":
+        """Add movie to Radarr."""
+        self.movie_data = self.radarr_client.add_movie(
+            self.tmdb_id, self.root_folder, self.quality_profile_id
+        )
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
+        """Delete movie files and Radarr entry."""
+        del exc_type, exc_val, exc_tb
+        if self.movie_data is None:
+            return
+        try:
+            self.radarr_client.remove_movie(
+                self.id, self.temp_media_root, self.directory
+            )
+        except Exception as exc:
+            print(f"Error during movie cleanup: {exc}")
+
+    @property
+    def id(self) -> int:
+        """Radarr movie ID."""
+        return self.data["id"]
+
+    @property
+    def title(self) -> str:
+        """Movie title returned by Radarr."""
+        return self.data["title"]
+
+    @property
+    def directory(self) -> Path:
+        """Host path corresponding to Radarr movie path."""
+        movie_path = Path(self.data["path"])
+        return self.temp_media_root / movie_path.relative_to(self.root_folder)
+
+    @property
+    def data(self) -> dict[str, Any]:
+        """Full movie data."""
+        if self.movie_data is None:
+            raise RuntimeError("Movie not added yet - use within context manager")
+        return self.movie_data

--- a/tests/integration/fixtures/radarr_client.py
+++ b/tests/integration/fixtures/radarr_client.py
@@ -1,0 +1,161 @@
+"""Radarr API client for integration testing."""
+
+import time
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+from sonarr_metadata_rewrite.retry_utils import retry
+from tests.integration.fixtures.arr_client import ArrClient
+
+
+class RadarrClient(ArrClient):
+    """Small Radarr API client used by integration tests."""
+
+    def wait_for_ready(self, max_attempts: int = 30, delay: float = 1.0) -> bool:
+        """Wait for Radarr API readiness."""
+        timeout_sec = max_attempts * delay
+
+        @retry(
+            timeout=timeout_sec,
+            interval=delay,
+            log_interval=5.0,
+            exceptions=(httpx.RequestError, httpx.HTTPStatusError),
+        )
+        def check_status() -> bool:
+            response = self._make_request("GET", "/api/v3/system/status", timeout=5.0)
+            response.raise_for_status()
+            return True
+
+        try:
+            return check_status()
+        except Exception as exc:
+            print(f"Radarr failed to become ready: {exc}")
+            return False
+
+    def add_movie(
+        self,
+        tmdb_id: int,
+        root_folder: str = "/movies",
+        quality_profile_id: int = 1,
+    ) -> dict[str, Any]:
+        """Add movie from TMDB lookup without searching for a release."""
+        self.ensure_root_folder(root_folder)
+        response = self._make_request(
+            "GET", "/api/v3/movie/lookup", params={"term": f"tmdb:{tmdb_id}"}
+        )
+        response.raise_for_status()
+        lookup_results = response.json()
+        if not lookup_results:
+            raise ValueError(f"No movie found for TMDB ID: {tmdb_id}")
+
+        movie_data = lookup_results[0]
+        movie_data.update(
+            {
+                "tmdbId": tmdb_id,
+                "rootFolderPath": root_folder,
+                "qualityProfileId": quality_profile_id,
+                "monitored": True,
+                "minimumAvailability": "released",
+                "addOptions": {"searchForMovie": False},
+            }
+        )
+        response = self._make_request("POST", "/api/v3/movie", json=movie_data)
+        response.raise_for_status()
+        return response.json()
+
+    def ensure_root_folder(self, root_folder: str) -> None:
+        """Register mounted movie root when Radarr has not seen it yet."""
+        response = self._make_request("GET", "/api/v3/rootfolder")
+        response.raise_for_status()
+        if any(folder.get("path") == root_folder for folder in response.json()):
+            return
+        response = self._make_request(
+            "POST", "/api/v3/rootfolder", json={"path": root_folder}
+        )
+        response.raise_for_status()
+
+    def trigger_disk_scan(self, movie_id: int) -> bool:
+        """Trigger a Radarr rescan for one movie."""
+        response = self._make_request(
+            "POST", "/api/v3/command", json={"name": "RescanMovie", "movieId": movie_id}
+        )
+        return response.status_code in (200, 201)
+
+    def get_movie(self, movie_id: int) -> dict[str, Any]:
+        """Get movie details, including imported file state."""
+        response = self._make_request("GET", f"/api/v3/movie/{movie_id}")
+        response.raise_for_status()
+        return response.json()
+
+    def configure_metadata_settings(self, use_movie_nfo: bool) -> bool:
+        """Enable Kodi/Emby movie metadata and images for selected NFO mode."""
+        response = self._make_request("GET", "/api/v3/metadata")
+        response.raise_for_status()
+        metadata_configs = response.json()
+        field_values = {
+            "moviemetadata": True,
+            "movieimages": True,
+            "usemovienfo": use_movie_nfo,
+        }
+        provider = next(
+            (
+                config
+                for config in metadata_configs
+                if any(
+                    name in config.get("name", "").lower()
+                    for name in ("kodi", "xbmc", "emby")
+                )
+                and set(field_values).issubset(
+                    {
+                        field.get("name", "").lower()
+                        for field in config.get("fields", [])
+                    }
+                )
+            ),
+            None,
+        )
+        if provider is None:
+            raise ValueError(
+                "No Kodi/XBMC/Emby metadata provider supports movieMetadata, "
+                "movieImages, and UseMovieNfo"
+            )
+        provider["enable"] = True
+        for field in provider["fields"]:
+            field_name = field.get("name", "").lower()
+            if field_name in field_values:
+                field["value"] = field_values[field_name]
+
+        response = self._make_request(
+            "PUT", f"/api/v3/metadata/{provider['id']}", json=provider
+        )
+        return response.is_success
+
+    def remove_movie(
+        self,
+        movie_id: int,
+        media_root: Path,
+        movie_directory: Path,
+        timeout: float = 30.0,
+    ) -> bool:
+        """Remove movie and wait for Radarr to delete its directory."""
+        response = self._make_request(
+            "DELETE", f"/api/v3/movie/{movie_id}", params={"deleteFiles": "true"}
+        )
+        if not response.is_success:
+            return False
+
+        start_time = time.time()
+        while time.time() - start_time < timeout:
+            if not movie_directory.exists():
+                return True
+            time.sleep(1)
+
+        if movie_directory.exists():
+            remaining_files = list(movie_directory.rglob("*"))
+            raise RuntimeError(
+                f"Movie directory {movie_directory} still exists after {timeout}s. "
+                f"Remaining files: {remaining_files}"
+            )
+        return True

--- a/tests/integration/fixtures/sonarr_client.py
+++ b/tests/integration/fixtures/sonarr_client.py
@@ -7,15 +7,11 @@ from typing import Any
 import httpx
 
 from sonarr_metadata_rewrite.retry_utils import retry
+from tests.integration.fixtures.arr_client import ArrClient
 
 
-class SonarrClient:
+class SonarrClient(ArrClient):
     """Simple Sonarr API client for integration tests."""
-
-    def __init__(self, base_url: str, api_key: str | None = None):
-        self.base_url = base_url.rstrip("/")
-        self.api_key = api_key
-        self.client = httpx.Client(timeout=30.0)
 
     def wait_for_ready(self, max_attempts: int = 30, delay: float = 1.0) -> bool:
         """Wait for Sonarr to be ready and responding."""
@@ -52,20 +48,6 @@ class SonarrClient:
         except Exception as e:
             print(f"Sonarr failed to become ready: {e}")
             return False
-
-    def _make_request(
-        self, method: str, endpoint: str, **kwargs: Any
-    ) -> httpx.Response:
-        """Make authenticated request to Sonarr API."""
-        url = f"{self.base_url}{endpoint}"
-
-        # Add API key if we have one
-        if self.api_key:
-            if "params" not in kwargs:
-                kwargs["params"] = {}
-            kwargs["params"]["apikey"] = self.api_key
-
-        return self.client.request(method, url, **kwargs)
 
     def add_series(
         self,
@@ -266,7 +248,3 @@ class SonarrClient:
             )
 
         return True
-
-    def close(self) -> None:
-        """Close the HTTP client."""
-        self.client.close()

--- a/tests/integration/test_helpers.py
+++ b/tests/integration/test_helpers.py
@@ -17,6 +17,8 @@ from sonarr_metadata_rewrite.file_utils import (
 from sonarr_metadata_rewrite.image_utils import read_embedded_marker
 from sonarr_metadata_rewrite.models import ImageCandidate
 from sonarr_metadata_rewrite.retry_utils import retry
+from tests.integration.fixtures.movie_manager import MovieManager
+from tests.integration.fixtures.radarr_client import RadarrClient
 from tests.integration.fixtures.series_manager import SeriesManager
 from tests.integration.fixtures.sonarr_client import SonarrClient
 from tests.integration.fixtures.subprocess_service_manager import (
@@ -95,6 +97,17 @@ def create_fake_multi_episode_file(
     sample_file = Path(__file__).parent / "fixtures" / "sample_episode.mkv"
     shutil.copy2(sample_file, episode_file)
     return episode_file
+
+
+def create_fake_movie_file(movie: MovieManager) -> Path:
+    """Copy existing valid sample MKV using Radarr's expected movie filename."""
+    movie.directory.mkdir(parents=True, exist_ok=True)
+    year = movie.data.get("year")
+    filename = f"{movie.title} ({year}).mkv" if year else f"{movie.title}.mkv"
+    movie_file = movie.directory / filename
+    sample_file = Path(__file__).parent / "fixtures" / "sample_episode.mkv"
+    shutil.copy2(sample_file, movie_file)
+    return movie_file
 
 
 def wait_for_nfo_files(
@@ -241,6 +254,63 @@ class SeriesWithNfos:
         """Clean up series."""
         if self.series:
             self.series.__exit__(exc_type, exc_val, exc_tb)
+
+
+class MovieWithNfos:
+    """Create Radarr movie, import synthetic video, and wait for Radarr assets."""
+
+    def __init__(
+        self,
+        radarr: RadarrClient,
+        media_root: Path,
+        tmdb_id: int,
+        use_movie_nfo: bool,
+    ):
+        self.radarr = radarr
+        self.media_root = media_root
+        self.tmdb_id = tmdb_id
+        self.use_movie_nfo = use_movie_nfo
+        self.movie: MovieManager | None = None
+
+    def __enter__(self) -> tuple[Path, list[Path]]:
+        """Import movie and return Radarr-created NFO and artwork paths."""
+        self.movie = MovieManager(self.radarr, self.tmdb_id, "/movies", self.media_root)
+        self.movie.__enter__()
+        movie_file = create_fake_movie_file(self.movie)
+        if not self.radarr.trigger_disk_scan(self.movie.id):
+            raise RuntimeError("Failed to trigger Radarr disk scan")
+
+        @retry(timeout=30.0, interval=1.0, log_interval=2.0)
+        def wait_for_import() -> None:
+            assert self.movie is not None
+            movie_data = self.radarr.get_movie(self.movie.id)
+            assert movie_data.get("hasFile"), "Radarr scan has not imported movie file"
+
+        wait_for_import()
+        nfo_file = (
+            self.movie.directory / "movie.nfo"
+            if self.use_movie_nfo
+            else movie_file.with_suffix(".nfo")
+        )
+        image_files = [
+            self.movie.directory / "poster.jpg",
+        ]
+        # Radarr's current TMDB metadata output creates poster/fanart but not
+        # clearlogo. Movie clearlogo rewriting remains covered by unit tests.
+
+        @retry(timeout=30.0, interval=0.5, log_interval=2.0)
+        def wait_for_radarr_assets() -> None:
+            assert nfo_file.exists(), f"Radarr did not create NFO: {nfo_file}"
+            for image_file in image_files:
+                assert image_file.exists(), f"Radarr did not create image: {image_file}"
+
+        wait_for_radarr_assets()
+        return nfo_file, image_files
+
+    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
+        """Remove Radarr movie and generated files."""
+        if self.movie:
+            self.movie.__exit__(exc_type, exc_val, exc_tb)
 
 
 class ServiceRunner:

--- a/tests/integration/test_radarr_integration.py
+++ b/tests/integration/test_radarr_integration.py
@@ -1,0 +1,80 @@
+"""Integration tests using real Radarr-generated movie metadata and artwork."""
+
+from pathlib import Path
+
+import pytest
+
+from tests.integration.fixtures.radarr_client import RadarrClient
+from tests.integration.test_helpers import (
+    MovieWithNfos,
+    ServiceRunner,
+    parse_nfo_content,
+    verify_images,
+    verify_translations,
+)
+
+# Verified against TMDB /movie/550/images during test development: zh-CN has
+# poster and logo candidates. Missing upstream assets must fail this test.
+FIGHT_CLUB_TMDB_ID = 550
+
+
+def verify_movie_output(nfo_file: Path, image_files: list[Path]) -> None:
+    """Verify translated movie document and localized artwork markers."""
+    verify_translations([nfo_file], "zh", ["zh", "en"])
+    verify_images(image_files, expected_language="zh-CN")
+    metadata = parse_nfo_content(nfo_file)
+    assert metadata["root_tag"] == "movie"
+    assert metadata["title"].strip(), "Movie NFO has no translated title"
+    assert metadata["plot"].strip(), "Movie NFO has no translated plot"
+
+
+@pytest.mark.integration
+@pytest.mark.slow
+@pytest.mark.parametrize(
+    ("use_movie_nfo", "service_config"),
+    [
+        (True, {"ENABLE_FILE_SCANNER": "false"}),
+        (False, {"ENABLE_FILE_SCANNER": "false"}),
+        (True, {"ENABLE_FILE_MONITOR": "false"}),
+        (False, {"ENABLE_FILE_MONITOR": "false"}),
+    ],
+    ids=[
+        "movie-nfo-file-monitor",
+        "video-named-nfo-file-monitor",
+        "movie-nfo-file-scanner",
+        "video-named-nfo-file-scanner",
+    ],
+)
+def test_radarr_movie_metadata_and_images(
+    temp_media_root: Path,
+    radarr_container: RadarrClient,
+    use_movie_nfo: bool,
+    service_config: dict[str, str],
+) -> None:
+    """Rewrite real Radarr movie NFO and localized poster."""
+    assert radarr_container.configure_metadata_settings(
+        use_movie_nfo
+    ), "Failed to configure Radarr Kodi/Emby metadata provider"
+
+    if service_config.get("ENABLE_FILE_SCANNER") == "false":
+        with ServiceRunner(
+            temp_media_root,
+            service_config,
+            startup_pattern="File monitor started",
+        ):
+            with MovieWithNfos(
+                radarr_container,
+                temp_media_root,
+                FIGHT_CLUB_TMDB_ID,
+                use_movie_nfo,
+            ) as (nfo_file, image_files):
+                verify_movie_output(nfo_file, image_files)
+    else:
+        with MovieWithNfos(
+            radarr_container,
+            temp_media_root,
+            FIGHT_CLUB_TMDB_ID,
+            use_movie_nfo,
+        ) as (nfo_file, image_files):
+            with ServiceRunner(temp_media_root, service_config):
+                verify_movie_output(nfo_file, image_files)

--- a/tests/unit/test_image_processor.py
+++ b/tests/unit/test_image_processor.py
@@ -19,7 +19,7 @@ from sonarr_metadata_rewrite.image_utils import (
     embed_marker_and_atomic_write,
     read_embedded_marker,
 )
-from sonarr_metadata_rewrite.models import ImageCandidate
+from sonarr_metadata_rewrite.models import ImageCandidate, TmdbIds
 from sonarr_metadata_rewrite.translator import Translator
 
 
@@ -55,9 +55,9 @@ def image_processor(
     return ImageProcessor(test_settings, translator)
 
 
-def create_test_nfo(path: Path, tmdb_id: int) -> None:
+def create_test_nfo(path: Path, tmdb_id: int, root_tag: str = "tvshow") -> None:
     """Create a test NFO file with TMDB ID."""
-    root = ET.Element("tvshow")
+    root = ET.Element(root_tag)
     uniqueid = ET.SubElement(root, "uniqueid", type="tmdb")
     uniqueid.text = str(tmdb_id)
     tree = ET.ElementTree(root)
@@ -147,6 +147,36 @@ class TestProcessSuccessScenarios:
         assert result.success is True, f"Processing failed: {result.message}"
         assert result.kind == "clearlogo"
         assert result.selected_language == "ja-JP"
+
+    def test_process_movie_clearlogo_success(
+        self, tmp_path: Path, image_processor: ImageProcessor
+    ) -> None:
+        """Test movie clearlogos use the shared image rewrite flow."""
+        movie_dir = tmp_path / "Movie"
+        movie_dir.mkdir()
+        clearlogo_path = movie_dir / "clearlogo.png"
+        create_test_image(clearlogo_path)
+        create_test_nfo(movie_dir / "movie.nfo", 550, root_tag="movie")
+
+        candidate = ImageCandidate(
+            file_path="/movie_clearlogo.png", iso_639_1="zh", iso_3166_1="CN"
+        )
+        image = Image.new("RGB", (100, 100), color="red")
+        output = BytesIO()
+        image.save(output, format="PNG")
+        response = Mock(content=output.getvalue())
+        image_processor.http_client.get = Mock(return_value=response)  # type: ignore[method-assign]
+
+        with mock_translator_select(image_processor, return_value=candidate) as select:
+            result = image_processor.process(clearlogo_path)
+
+        assert result.success is True, result.message
+        assert result.kind == "clearlogo"
+        select.assert_called_once_with(
+            TmdbIds(tmdb_id=550, media_type="movie"),
+            image_processor.settings.preferred_languages,
+            "clearlogo",
+        )
 
     def test_process_image_already_has_marker(
         self, tmp_path: Path, image_processor: ImageProcessor
@@ -516,8 +546,69 @@ class TestResolveTmdbIds:
         result = image_processor._resolve_tmdb_ids(poster_path, None)
 
         assert result is not None
-        assert result.series_id == 99999
+        assert result.tmdb_id == 99999
         assert result.season is None
+
+    def test_resolve_movie_ids_from_video_named_nfo(
+        self, tmp_path: Path, image_processor: ImageProcessor
+    ) -> None:
+        """Test movie root NFO names do not need to be movie.nfo."""
+        movie_dir = tmp_path / "Movie"
+        movie_dir.mkdir()
+        poster_path = movie_dir / "poster.jpg"
+        create_test_image(poster_path)
+        create_test_nfo(movie_dir / "Movie.2024.nfo", 550, root_tag="movie")
+
+        result = image_processor._resolve_tmdb_ids(poster_path, None)
+
+        assert result == TmdbIds(tmdb_id=550, media_type="movie")
+
+    def test_resolve_ignores_episode_nfo_next_to_tvshow(
+        self, tmp_path: Path, image_processor: ImageProcessor
+    ) -> None:
+        """Test episode NFOs do not make TV artwork root selection ambiguous."""
+        series_dir = tmp_path / "Series"
+        series_dir.mkdir()
+        poster_path = series_dir / "poster.jpg"
+        create_test_image(poster_path)
+        create_test_nfo(series_dir / "tvshow.nfo", 99999)
+        create_test_nfo(series_dir / "episode.nfo", 99999, root_tag="episodedetails")
+
+        result = image_processor._resolve_tmdb_ids(poster_path, None)
+
+        assert result is not None
+        assert result.tmdb_id == 99999
+        assert result.media_type == "tv"
+
+    @pytest.mark.parametrize("root_count", [0, 2])
+    def test_resolve_rejects_missing_or_ambiguous_roots(
+        self, tmp_path: Path, image_processor: ImageProcessor, root_count: int
+    ) -> None:
+        """Test image ownership needs exactly one same-directory root NFO."""
+        image_dir = tmp_path / "Media"
+        image_dir.mkdir()
+        poster_path = image_dir / "poster.jpg"
+        create_test_image(poster_path)
+        for index in range(root_count):
+            create_test_nfo(
+                image_dir / f"root-{index}.nfo",
+                550 + index,
+                root_tag="movie" if index else "tvshow",
+            )
+
+        assert image_processor._resolve_tmdb_ids(poster_path, None) is None
+
+    def test_resolve_rejects_movie_season_poster(
+        self, tmp_path: Path, image_processor: ImageProcessor
+    ) -> None:
+        """Test movie roots cannot select season artwork."""
+        movie_dir = tmp_path / "Movie"
+        movie_dir.mkdir()
+        poster_path = movie_dir / "season01-poster.jpg"
+        create_test_image(poster_path)
+        create_test_nfo(movie_dir / "movie.nfo", 550, root_tag="movie")
+
+        assert image_processor._resolve_tmdb_ids(poster_path, 1) is None
 
 
 class TestDownloadAndWriteImage:

--- a/tests/unit/test_image_processor.py
+++ b/tests/unit/test_image_processor.py
@@ -580,6 +580,21 @@ class TestResolveTmdbIds:
         assert result.tmdb_id == 99999
         assert result.media_type == "tv"
 
+    def test_resolve_ignores_malformed_nfo_next_to_movie(
+        self, tmp_path: Path, image_processor: ImageProcessor
+    ) -> None:
+        """Test malformed NFO files do not prevent movie artwork resolution."""
+        movie_dir = tmp_path / "Movie"
+        movie_dir.mkdir()
+        poster_path = movie_dir / "poster.jpg"
+        create_test_image(poster_path)
+        (movie_dir / "broken.nfo").write_text("<movie>", encoding="utf-8")
+        create_test_nfo(movie_dir / "movie.nfo", 550, root_tag="movie")
+
+        assert image_processor._resolve_tmdb_ids(poster_path, None) == TmdbIds(
+            tmdb_id=550, media_type="movie"
+        )
+
     @pytest.mark.parametrize("root_count", [0, 2])
     def test_resolve_rejects_missing_or_ambiguous_roots(
         self, tmp_path: Path, image_processor: ImageProcessor, root_count: int

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -32,7 +32,7 @@ class TestCli:
                     result = runner.invoke(cli)
 
             # Check the initial output
-            assert "🚀 Starting Sonarr Metadata Rewrite..." in result.output
+            assert "🚀 Starting Sonarr and Radarr Metadata Rewrite..." in result.output
             assert (
                 f"✅ TMDB API key loaded (ending in ...{test_key[-4:]})"
                 in result.output
@@ -76,9 +76,9 @@ class TestCli:
         result = runner.invoke(cli, ["--help"])
 
         assert result.exit_code == 0
-        assert "Sonarr Metadata Rewrite" in result.output
+        assert "Sonarr and Radarr Metadata Rewrite" in result.output
         assert (
-            "A long-running service that monitors Sonarr-generated .nfo files"
+            "A long-running service that monitors Sonarr TV and Radarr movie"
             in result.output
         )
         assert "In rollback mode, restores original files" in result.output
@@ -109,7 +109,7 @@ class TestCli:
                     result = runner.invoke(cli)
 
             # Check the output
-            assert "🚀 Starting Sonarr Metadata Rewrite..." in result.output
+            assert "🚀 Starting Sonarr and Radarr Metadata Rewrite..." in result.output
             assert "🔧 Service mode: rollback" in result.output
             assert "🔄 Executing rollback operation..." in result.output
             assert "✅ Rollback completed successfully" in result.output
@@ -140,7 +140,7 @@ class TestCli:
                     result = runner.invoke(cli)
 
             # Check the output
-            assert "🚀 Starting Sonarr Metadata Rewrite..." in result.output
+            assert "🚀 Starting Sonarr and Radarr Metadata Rewrite..." in result.output
             assert "🔧 Service mode: rollback" in result.output
             assert "🔄 Executing rollback operation..." in result.output
             assert (

--- a/tests/unit/test_metadata_processor.py
+++ b/tests/unit/test_metadata_processor.py
@@ -255,6 +255,69 @@ def test_process_file_episode_no_tmdb_id_no_parent_tvshow(
     )
 
 
+def test_find_parent_metadata_ignores_malformed_nfo(
+    processor: MetadataProcessor, test_data_dir: Path
+) -> None:
+    """Test parent lookup skips malformed NFO files while searching upward."""
+    series_dir = test_data_dir / "Series"
+    season_dir = series_dir / "Season 1"
+    season_dir.mkdir(parents=True)
+    episode_path = season_dir / "episode.nfo"
+    episode_path.write_text("<episodedetails />", encoding="utf-8")
+    (season_dir / "broken.nfo").write_text("<tvshow>", encoding="utf-8")
+    (series_dir / "Series.nfo").write_text(
+        '<tvshow><uniqueid type="tmdb">1396</uniqueid></tvshow>',
+        encoding="utf-8",
+    )
+
+    parent = processor._find_parent_metadata_info(episode_path)
+
+    assert parent is not None
+    assert parent.tmdb_id == 1396
+
+
+def test_find_parent_metadata_rejects_ambiguous_roots(
+    processor: MetadataProcessor, test_data_dir: Path
+) -> None:
+    """Test parent lookup rejects directories with multiple TV roots."""
+    episode_path = test_data_dir / "Season 1" / "episode.nfo"
+    episode_path.parent.mkdir()
+    episode_path.write_text("<episodedetails />", encoding="utf-8")
+    for name, tmdb_id in (("Series.nfo", 1396), ("tvshow.nfo", 999)):
+        (episode_path.parent / name).write_text(
+            f'<tvshow><uniqueid type="tmdb">{tmdb_id}</uniqueid></tvshow>',
+            encoding="utf-8",
+        )
+
+    assert processor._find_parent_metadata_info(episode_path) is None
+
+
+@pytest.mark.parametrize(
+    ("season", "episode"),
+    [(None, 1), (1, None)],
+)
+def test_build_tmdb_ids_rejects_episode_without_numbers(
+    processor: MetadataProcessor,
+    test_data_dir: Path,
+    season: int | None,
+    episode: int | None,
+) -> None:
+    """Test episodes need both season and episode numbers."""
+    metadata_info = MetadataInfo(
+        tmdb_id=1396,
+        file_type="episodedetails",
+        season=season,
+        episode=episode,
+    )
+
+    assert (
+        processor._build_tmdb_ids_from_metadata(
+            metadata_info, test_data_dir / "episode.nfo"
+        )
+        is None
+    )
+
+
 def test_process_file_invalid_xml(
     processor: MetadataProcessor,
     test_data_dir: Path,

--- a/tests/unit/test_metadata_processor.py
+++ b/tests/unit/test_metadata_processor.py
@@ -65,7 +65,7 @@ def test_process_file_series_success(
     assert_process_result(
         result,
         expected_success=True,
-        expected_series_id=1396,
+        expected_tmdb_id=1396,
         expected_file_modified=True,
         expected_language="zh-CN",
         expected_message_contains="Successfully translated",
@@ -85,13 +85,64 @@ def test_process_file_episode_success(
     assert_process_result(
         result,
         expected_success=True,
-        expected_series_id=1396,
+        expected_tmdb_id=1396,
         expected_season=1,
         expected_episode=1,
         expected_file_modified=True,
         expected_language="zh-CN",
         expected_message_contains="Successfully translated",
     )
+
+
+def test_process_file_movie_parses_and_preserves_other_xml_fields(
+    processor: MetadataProcessor,
+    test_data_dir: Path,
+    create_test_files: Callable[[str, Path], Path],
+) -> None:
+    """Test movie NFO translation uses movie IDs and changes only title and plot."""
+    test_path = create_test_files("movie.nfo", test_data_dir / "movie.nfo")
+
+    result = processor.process_file(test_path)
+
+    assert_process_result(
+        result,
+        expected_success=True,
+        expected_tmdb_id=550,
+        expected_file_modified=True,
+        expected_language="zh-CN",
+    )
+    assert result.tmdb_ids is not None
+    assert result.tmdb_ids.media_type == "movie"
+    root = ET.parse(test_path).getroot()
+    assert root.tag == "movie"
+    assert root.findtext("title") == "示例剧集"
+    assert root.findtext("plot") == "这是一个示例描述"
+    assert root.findtext("originaltitle") == "Original Movie Title"
+    assert root.findtext("sorttitle") == "Movie, Original"
+    assert root.findtext("uniqueid[@type='tmdb']") == "550"
+    assert root.findtext("rating") == "8.4"
+    assert root.findtext("watched") == "false"
+
+
+def test_process_file_movie_without_tmdb_id_skips_external_resolution(
+    processor: MetadataProcessor,
+    test_data_dir: Path,
+    create_test_files: Callable[[str, Path], Path],
+) -> None:
+    """Test movie NFOs require a direct TMDB ID."""
+    test_path = create_test_files("movie_no_tmdb_id.nfo", test_data_dir / "movie.nfo")
+
+    result = processor.process_file(test_path)
+
+    assert_process_result(
+        result,
+        expected_success=False,
+        expected_file_modified=False,
+        expected_message_contains="No TMDB ID found",
+    )
+    assert isinstance(processor.translator, Mock)
+    processor.translator.find_tmdb_id_by_external_id.assert_not_called()
+    processor.translator.get_translations.assert_not_called()
 
 
 def test_process_file_language_preference(
@@ -173,7 +224,7 @@ def test_process_file_episode_no_tmdb_id_with_parent_tvshow(
     assert_process_result(
         result,
         expected_success=True,
-        expected_series_id=1396,  # From tvshow.nfo
+        expected_tmdb_id=1396,  # From tvshow.nfo
         expected_season=1,
         expected_episode=1,
         expected_file_modified=True,
@@ -269,7 +320,7 @@ def test_process_file_no_preferred_translation(
     assert "preferred languages [zh-CN]" in result.message
     assert "Available: [en, ja-JP]" in result.message
     assert result.tmdb_ids is not None
-    assert result.tmdb_ids.series_id == 1396
+    assert result.tmdb_ids.tmdb_id == 1396
     assert result.file_modified is False  # File was not changed
     assert result.translated_content is None
 
@@ -1103,7 +1154,7 @@ def test_process_file_tvdb_id_only_success(
     assert_process_result(
         result,
         expected_success=True,
-        expected_series_id=1396,
+        expected_tmdb_id=1396,
         expected_file_modified=True,
         expected_language="zh-CN",
         expected_message_contains="Successfully translated",
@@ -1137,7 +1188,7 @@ def test_process_file_imdb_id_only_success(
     assert_process_result(
         result,
         expected_success=True,
-        expected_series_id=1396,
+        expected_tmdb_id=1396,
         expected_file_modified=True,
         expected_language="zh-CN",
         expected_message_contains="Successfully translated",
@@ -1194,7 +1245,7 @@ def test_process_file_episode_inherits_parent_tvdb_id(
     assert_process_result(
         result,
         expected_success=True,
-        expected_series_id=1396,
+        expected_tmdb_id=1396,
         expected_season=1,
         expected_episode=1,
         expected_file_modified=True,
@@ -1271,7 +1322,7 @@ def test_process_file_mixed_id_scenarios(
     assert_process_result(
         result,
         expected_success=True,
-        expected_series_id=1396,  # From parent TMDB ID, not external lookup
+        expected_tmdb_id=1396,  # From parent TMDB ID, not external lookup
         expected_season=1,
         expected_episode=1,
         expected_file_modified=True,
@@ -1318,7 +1369,7 @@ def test_process_file_episode_external_id_priority_over_parent_external_id(
     assert_process_result(
         result,
         expected_success=True,
-        expected_series_id=2468,  # From episode's external ID lookup
+        expected_tmdb_id=2468,  # From episode's external ID lookup
         expected_season=1,
         expected_episode=1,
         expected_file_modified=True,
@@ -1413,7 +1464,7 @@ def test_process_file_multi_episode_partial_update(
     assert_process_result(
         result,
         expected_success=True,
-        expected_series_id=1396,
+        expected_tmdb_id=1396,
         expected_season=1,
         expected_episode=1,
         expected_file_modified=True,
@@ -1477,7 +1528,7 @@ def test_process_file_multi_episode_restore_from_backup_when_translation_missing
     assert_process_result(
         result,
         expected_success=True,
-        expected_series_id=1396,
+        expected_tmdb_id=1396,
         expected_season=1,
         expected_episode=1,
         expected_file_modified=True,
@@ -1516,7 +1567,7 @@ def test_process_file_multi_episode_no_translation_available(
     assert_process_result(
         result,
         expected_success=False,
-        expected_series_id=1396,
+        expected_tmdb_id=1396,
         expected_season=1,
         expected_episode=1,
         expected_file_modified=False,
@@ -1576,7 +1627,7 @@ def test_process_file_multi_episode_skips_entry_without_episode_numbers(
     assert_process_result(
         result,
         expected_success=True,
-        expected_series_id=1396,
+        expected_tmdb_id=1396,
         expected_season=1,
         expected_episode=1,
         expected_file_modified=True,
@@ -1642,7 +1693,7 @@ def test_process_file_multi_episode_reports_already_matched_entries(
     assert_process_result(
         result,
         expected_success=True,
-        expected_series_id=1396,
+        expected_tmdb_id=1396,
         expected_season=1,
         expected_episode=1,
         expected_file_modified=True,

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -17,7 +17,7 @@ from sonarr_metadata_rewrite.models import (
 
 def test_tmdb_ids_tv() -> None:
     """Test TmdbIds for TV show files."""
-    tmdb_ids = TmdbIds(tmdb_id=12345)
+    tmdb_ids = TmdbIds(tmdb_id=12345, media_type="tv")
     assert tmdb_ids.tmdb_id == 12345
     assert tmdb_ids.media_type == "tv"
     assert tmdb_ids.season is None
@@ -26,7 +26,7 @@ def test_tmdb_ids_tv() -> None:
 
 def test_tmdb_ids_episode() -> None:
     """Test TmdbIds for episode files."""
-    tmdb_ids = TmdbIds(tmdb_id=12345, season=1, episode=1)
+    tmdb_ids = TmdbIds(tmdb_id=12345, media_type="tv", season=1, episode=1)
     assert tmdb_ids.tmdb_id == 12345
     assert tmdb_ids.season == 1
     assert tmdb_ids.episode == 1
@@ -34,7 +34,7 @@ def test_tmdb_ids_episode() -> None:
 
 def test_tmdb_ids_season_artwork() -> None:
     """Test TmdbIds allows TV season artwork without an episode."""
-    tmdb_ids = TmdbIds(tmdb_id=12345, season=1)
+    tmdb_ids = TmdbIds(tmdb_id=12345, media_type="tv", season=1)
 
     assert str(tmdb_ids) == "tv/12345"
     assert tmdb_ids.season == 1
@@ -63,7 +63,7 @@ def test_process_result() -> None:
         success=True,
         file_path=Path("/test/path.nfo"),
         message="Test message",
-        tmdb_ids=TmdbIds(tmdb_id=12345),
+        tmdb_ids=TmdbIds(tmdb_id=12345, media_type="tv"),
         backup_created=True,
         file_modified=True,
         translated_content=translated_content,
@@ -88,7 +88,7 @@ def test_process_result_no_translation() -> None:
             "File unchanged - no translation available in preferred languages [zh-CN]. "
             "Available: [en, ja-JP]"
         ),
-        tmdb_ids=TmdbIds(tmdb_id=12345),
+        tmdb_ids=TmdbIds(tmdb_id=12345, media_type="tv"),
         file_modified=False,
         translated_content=None,
     )
@@ -162,7 +162,7 @@ def test_metadata_process_result_backward_compatibility() -> None:
         success=True,
         file_path=Path("/test/tvshow.nfo"),
         message="NFO updated",
-        tmdb_ids=TmdbIds(tmdb_id=999, season=1, episode=1),
+        tmdb_ids=TmdbIds(tmdb_id=999, media_type="tv", season=1, episode=1),
         backup_created=True,
         file_modified=True,
         translated_content=translated_content,
@@ -200,4 +200,4 @@ def test_tmdb_ids_movie_rejects_season_or_episode() -> None:
 def test_tmdb_ids_episode_requires_season() -> None:
     """Test episodes cannot omit their season number."""
     with pytest.raises(ValueError, match="require a season"):
-        TmdbIds(tmdb_id=12345, episode=1)
+        TmdbIds(tmdb_id=12345, media_type="tv", episode=1)

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -2,6 +2,8 @@
 
 from pathlib import Path
 
+import pytest
+
 from sonarr_metadata_rewrite.models import (
     ImageCandidate,
     ImageProcessResult,
@@ -13,20 +15,30 @@ from sonarr_metadata_rewrite.models import (
 )
 
 
-def test_tmdb_ids_series() -> None:
-    """Test TmdbIds for series files."""
-    tmdb_ids = TmdbIds(series_id=12345)
-    assert tmdb_ids.series_id == 12345
+def test_tmdb_ids_tv() -> None:
+    """Test TmdbIds for TV show files."""
+    tmdb_ids = TmdbIds(tmdb_id=12345)
+    assert tmdb_ids.tmdb_id == 12345
+    assert tmdb_ids.media_type == "tv"
     assert tmdb_ids.season is None
     assert tmdb_ids.episode is None
 
 
 def test_tmdb_ids_episode() -> None:
     """Test TmdbIds for episode files."""
-    tmdb_ids = TmdbIds(series_id=12345, season=1, episode=1)
-    assert tmdb_ids.series_id == 12345
+    tmdb_ids = TmdbIds(tmdb_id=12345, season=1, episode=1)
+    assert tmdb_ids.tmdb_id == 12345
     assert tmdb_ids.season == 1
     assert tmdb_ids.episode == 1
+
+
+def test_tmdb_ids_season_artwork() -> None:
+    """Test TmdbIds allows TV season artwork without an episode."""
+    tmdb_ids = TmdbIds(tmdb_id=12345, season=1)
+
+    assert str(tmdb_ids) == "tv/12345"
+    assert tmdb_ids.season == 1
+    assert tmdb_ids.episode is None
 
 
 def test_translated_content() -> None:
@@ -51,7 +63,7 @@ def test_process_result() -> None:
         success=True,
         file_path=Path("/test/path.nfo"),
         message="Test message",
-        tmdb_ids=TmdbIds(series_id=12345),
+        tmdb_ids=TmdbIds(tmdb_id=12345),
         backup_created=True,
         file_modified=True,
         translated_content=translated_content,
@@ -60,7 +72,7 @@ def test_process_result() -> None:
     assert result.file_path == Path("/test/path.nfo")
     assert result.message == "Test message"
     assert result.tmdb_ids is not None
-    assert result.tmdb_ids.series_id == 12345
+    assert result.tmdb_ids.tmdb_id == 12345
     assert result.backup_created is True
     assert result.file_modified is True
     assert result.translated_content is not None
@@ -76,7 +88,7 @@ def test_process_result_no_translation() -> None:
             "File unchanged - no translation available in preferred languages [zh-CN]. "
             "Available: [en, ja-JP]"
         ),
-        tmdb_ids=TmdbIds(series_id=12345),
+        tmdb_ids=TmdbIds(tmdb_id=12345),
         file_modified=False,
         translated_content=None,
     )
@@ -150,7 +162,7 @@ def test_metadata_process_result_backward_compatibility() -> None:
         success=True,
         file_path=Path("/test/tvshow.nfo"),
         message="NFO updated",
-        tmdb_ids=TmdbIds(series_id=999, season=1, episode=1),
+        tmdb_ids=TmdbIds(tmdb_id=999, season=1, episode=1),
         backup_created=True,
         file_modified=True,
         translated_content=translated_content,
@@ -158,7 +170,7 @@ def test_metadata_process_result_backward_compatibility() -> None:
 
     # Metadata-specific fields
     assert result.tmdb_ids is not None
-    assert result.tmdb_ids.series_id == 999
+    assert result.tmdb_ids.tmdb_id == 999
     assert result.tmdb_ids.season == 1
     assert result.tmdb_ids.episode == 1
     assert result.translated_content is not None
@@ -168,3 +180,24 @@ def test_metadata_process_result_backward_compatibility() -> None:
     assert result.success is True
     assert result.file_path == Path("/test/tvshow.nfo")
     assert result.backup_created is True
+
+
+def test_tmdb_ids_movie_path() -> None:
+    """Test TmdbIds builds movie resource paths."""
+    tmdb_ids = TmdbIds(tmdb_id=550, media_type="movie")
+
+    assert str(tmdb_ids) == "movie/550"
+    assert tmdb_ids.season is None
+    assert tmdb_ids.episode is None
+
+
+def test_tmdb_ids_movie_rejects_season_or_episode() -> None:
+    """Test movie IDs cannot include TV episode fields."""
+    with pytest.raises(ValueError, match="cannot include season or episode"):
+        TmdbIds(tmdb_id=550, media_type="movie", season=1)
+
+
+def test_tmdb_ids_episode_requires_season() -> None:
+    """Test episodes cannot omit their season number."""
+    with pytest.raises(ValueError, match="require a season"):
+        TmdbIds(tmdb_id=12345, episode=1)

--- a/tests/unit/test_translator.py
+++ b/tests/unit/test_translator.py
@@ -120,11 +120,11 @@ def test_translator_initialization(translator: Translator) -> None:
 def test_tmdb_ids_string_representation() -> None:
     """Test TmdbIds __str__ method."""
     # Series
-    series_ids = TmdbIds(series_id=12345)
+    series_ids = TmdbIds(tmdb_id=12345)
     assert str(series_ids) == "tv/12345"
 
     # Episode
-    episode_ids = TmdbIds(series_id=12345, season=1, episode=2)
+    episode_ids = TmdbIds(tmdb_id=12345, season=1, episode=2)
     assert str(episode_ids) == "tv/12345/season/1/episode/2"
 
 
@@ -139,7 +139,7 @@ def test_get_translations_series_success(
     mock_response.json.return_value = mock_series_response
     mock_get.return_value = mock_response
 
-    tmdb_ids = TmdbIds(series_id=12345)
+    tmdb_ids = TmdbIds(tmdb_id=12345)
     translations = translator.get_translations(tmdb_ids)
 
     # Verify API call
@@ -185,7 +185,7 @@ def test_get_translations_episode_success(
     mock_response.json.return_value = mock_episode_response
     mock_get.return_value = mock_response
 
-    tmdb_ids = TmdbIds(series_id=12345, season=1, episode=2)
+    tmdb_ids = TmdbIds(tmdb_id=12345, season=1, episode=2)
     translations = translator.get_translations(tmdb_ids)
 
     # Verify API call with correct endpoint
@@ -206,12 +206,37 @@ def test_get_translations_episode_success(
 
 
 @patch("httpx.Client.get")
+def test_get_translations_movie_uses_movie_path_and_title(
+    mock_get: Mock, translator: Translator
+) -> None:
+    """Test movie translations use movie endpoint and data.title."""
+    mock_response = Mock()
+    mock_response.raise_for_status.return_value = None
+    mock_response.json.return_value = {
+        "translations": [
+            {
+                "iso_639_1": "zh",
+                "iso_3166_1": "CN",
+                "data": {"title": "电影标题", "overview": "电影剧情"},
+            }
+        ]
+    }
+    mock_get.return_value = mock_response
+
+    translations = translator.get_translations(TmdbIds(tmdb_id=550, media_type="movie"))
+
+    mock_get.assert_called_once_with("/movie/550/translations", params=None)
+    assert translations["zh-CN"].title.content == "电影标题"
+    assert translations["zh-CN"].description.content == "电影剧情"
+
+
+@patch("httpx.Client.get")
 def test_get_translations_http_error(mock_get: Mock, translator: Translator) -> None:
     """Test HTTP error handling."""
     # Mock HTTP error
     mock_get.side_effect = httpx.HTTPError("API error")
 
-    tmdb_ids = TmdbIds(series_id=12345)
+    tmdb_ids = TmdbIds(tmdb_id=12345)
 
     # Should raise the HTTP error (fail-fast)
     with pytest.raises(httpx.HTTPError, match="API error"):
@@ -229,7 +254,7 @@ def test_get_translations_json_decode_error(
     mock_response.json.side_effect = json.JSONDecodeError("Invalid JSON", "doc", 0)
     mock_get.return_value = mock_response
 
-    tmdb_ids = TmdbIds(series_id=12345)
+    tmdb_ids = TmdbIds(tmdb_id=12345)
 
     # Should raise the JSON decode error (fail-fast)
     with pytest.raises(json.JSONDecodeError, match="Invalid JSON"):
@@ -247,7 +272,7 @@ def test_get_translations_empty_response(
     mock_response.json.return_value = {"id": 12345, "translations": []}
     mock_get.return_value = mock_response
 
-    tmdb_ids = TmdbIds(series_id=12345)
+    tmdb_ids = TmdbIds(tmdb_id=12345)
     translations = translator.get_translations(tmdb_ids)
 
     # Should return empty dict when no translations available
@@ -280,7 +305,7 @@ def test_get_translations_filters_empty_data(
     }
     mock_get.return_value = mock_response
 
-    tmdb_ids = TmdbIds(series_id=12345)
+    tmdb_ids = TmdbIds(tmdb_id=12345)
     translations = translator.get_translations(tmdb_ids)
 
     # Should only include translations with content
@@ -293,7 +318,7 @@ def test_cache_functionality(
     translator: Translator, mock_series_response: dict[str, Any]
 ) -> None:
     """Test DiskCache functionality."""
-    tmdb_ids = TmdbIds(series_id=12345)
+    tmdb_ids = TmdbIds(tmdb_id=12345)
     cache_key = f"translations:{tmdb_ids}/translations"
 
     # Verify cache starts empty
@@ -320,7 +345,7 @@ def test_caching_integration(
     mock_response.json.return_value = mock_series_response
     mock_get.return_value = mock_response
 
-    tmdb_ids = TmdbIds(series_id=12345)
+    tmdb_ids = TmdbIds(tmdb_id=12345)
 
     # First call should hit API and cache result
     translations1 = translator.get_translations(tmdb_ids)
@@ -362,7 +387,7 @@ def test_get_original_details_series_success(
     mock_response.json.return_value = mock_series_details_response
     mock_get.return_value = mock_response
 
-    tmdb_ids = TmdbIds(series_id=68034)
+    tmdb_ids = TmdbIds(tmdb_id=68034)
     result = translator.get_original_details(tmdb_ids)
 
     # Verify API call
@@ -373,6 +398,25 @@ def test_get_original_details_series_success(
     original_language, original_title = result
     assert original_language == "zh"
     assert original_title == "大明王朝1566"
+
+
+@patch("httpx.Client.get")
+def test_get_original_details_movie_uses_movie_title_fields(
+    mock_get: Mock, translator: Translator
+) -> None:
+    """Test movie details use movie endpoint and original_title."""
+    mock_response = Mock()
+    mock_response.raise_for_status.return_value = None
+    mock_response.json.return_value = {
+        "original_language": "en",
+        "original_title": "Fight Club",
+    }
+    mock_get.return_value = mock_response
+
+    result = translator.get_original_details(TmdbIds(tmdb_id=550, media_type="movie"))
+
+    mock_get.assert_called_once_with("/movie/550", params=None)
+    assert result == ("en", "Fight Club")
 
 
 @patch("httpx.Client.get")
@@ -397,7 +441,7 @@ def test_get_original_details_episode_success(
 
     mock_get.side_effect = mock_side_effect
 
-    tmdb_ids = TmdbIds(series_id=12345, season=1, episode=1)
+    tmdb_ids = TmdbIds(tmdb_id=12345, season=1, episode=1)
     result = translator.get_original_details(tmdb_ids)
 
     # Verify both API calls were made
@@ -424,7 +468,7 @@ def test_get_original_details_http_error(
     # Mock HTTP error
     mock_get.side_effect = httpx.HTTPError("API error")
 
-    tmdb_ids = TmdbIds(series_id=12345)
+    tmdb_ids = TmdbIds(tmdb_id=12345)
 
     # Should raise the HTTP error (fail-fast behavior with new implementation)
     with pytest.raises(httpx.HTTPError, match="API error"):
@@ -446,7 +490,7 @@ def test_get_original_details_missing_data(
     }
     mock_get.return_value = mock_response
 
-    tmdb_ids = TmdbIds(series_id=12345)
+    tmdb_ids = TmdbIds(tmdb_id=12345)
     result = translator.get_original_details(tmdb_ids)
 
     # Should return None when required data is missing
@@ -464,7 +508,7 @@ def test_get_original_details_caching(
     mock_response.json.return_value = mock_series_details_response
     mock_get.return_value = mock_response
 
-    tmdb_ids = TmdbIds(series_id=68034)
+    tmdb_ids = TmdbIds(tmdb_id=68034)
 
     # First call should hit API and cache result
     result1 = translator.get_original_details(tmdb_ids)
@@ -500,7 +544,7 @@ def test_rate_limit_retry_success(
 
     mock_get.side_effect = [rate_limit_error, success_response]
 
-    tmdb_ids = TmdbIds(series_id=12345)
+    tmdb_ids = TmdbIds(tmdb_id=12345)
     translations = translator.get_translations(tmdb_ids)
 
     # Should have made 2 API calls (1 failed, 1 success)
@@ -528,7 +572,7 @@ def test_rate_limit_max_retries_exceeded(
     )
     mock_get.side_effect = rate_limit_error
 
-    tmdb_ids = TmdbIds(series_id=12345)
+    tmdb_ids = TmdbIds(tmdb_id=12345)
 
     # Should raise the rate limit error after exhausting retries
     with pytest.raises(httpx.HTTPStatusError, match="Too Many Requests"):
@@ -559,7 +603,7 @@ def test_non_rate_limit_http_error_no_retry(
     )
     mock_get.side_effect = server_error
 
-    tmdb_ids = TmdbIds(series_id=12345)
+    tmdb_ids = TmdbIds(tmdb_id=12345)
 
     # Should raise the error immediately without retries
     with pytest.raises(httpx.HTTPStatusError, match="Internal Server Error"):
@@ -590,7 +634,7 @@ def test_rate_limit_exponential_backoff_max_delay(
         )
         mock_get.side_effect = rate_limit_error
 
-        tmdb_ids = TmdbIds(series_id=12345)
+        tmdb_ids = TmdbIds(tmdb_id=12345)
 
         with pytest.raises(httpx.HTTPStatusError):
             translator.get_translations(tmdb_ids)
@@ -618,7 +662,7 @@ def test_rate_limit_preserves_cache_on_failure(
     )
     mock_get.side_effect = rate_limit_error
 
-    tmdb_ids = TmdbIds(series_id=12345)
+    tmdb_ids = TmdbIds(tmdb_id=12345)
     cache_key = f"translations:{tmdb_ids}"
 
     # Ensure cache is empty initially
@@ -882,7 +926,7 @@ def test_get_translations_cache_backward_compatibility_integration(
     )
 
     # Manually set old format data in cache to simulate pre-upgrade cache
-    tmdb_ids = TmdbIds(series_id=12345)
+    tmdb_ids = TmdbIds(tmdb_id=12345)
     cache_key = f"translations:{tmdb_ids}"
     translator.cache.set(cache_key, {"zh-CN": old_cached_content})
 
@@ -950,7 +994,7 @@ def test_get_translations_404_cached(mock_get: Mock, translator: Translator) -> 
     )
     mock_get.side_effect = not_found_error
 
-    tmdb_ids = TmdbIds(series_id=99999)  # Non-existent series
+    tmdb_ids = TmdbIds(tmdb_id=99999)  # Non-existent series
     cache_key = f"translations:{tmdb_ids}"
 
     # Verify cache starts empty
@@ -987,7 +1031,7 @@ def test_get_original_details_404_cached(
     )
     mock_get.side_effect = not_found_error
 
-    tmdb_ids = TmdbIds(series_id=99999)  # Non-existent series
+    tmdb_ids = TmdbIds(tmdb_id=99999)  # Non-existent series
     cache_key = f"original_details:{tmdb_ids}"
 
     # Verify cache starts empty
@@ -1111,7 +1155,7 @@ class TestSelectBestImage:
         mock_get.return_value.json.return_value = mock_images_response_posters
         mock_get.return_value.raise_for_status = Mock()
 
-        tmdb_ids = TmdbIds(series_id=12345, season=None, episode=None)
+        tmdb_ids = TmdbIds(tmdb_id=12345, season=None, episode=None)
         result = translator.select_best_image(tmdb_ids, ["en-US"], kind="poster")
 
         assert result is not None
@@ -1130,13 +1174,32 @@ class TestSelectBestImage:
         mock_get.return_value.json.return_value = mock_images_response_logos
         mock_get.return_value.raise_for_status = Mock()
 
-        tmdb_ids = TmdbIds(series_id=67890, season=None, episode=None)
+        tmdb_ids = TmdbIds(tmdb_id=67890, season=None, episode=None)
         result = translator.select_best_image(tmdb_ids, ["ja-JP"], kind="clearlogo")
 
         assert result is not None
         assert result.file_path == "/logo_ja.jpg"
         assert result.iso_639_1 == "ja"
         assert result.iso_3166_1 == "JP"
+
+    @patch("httpx.Client.get")
+    def test_select_best_image_movie_uses_movie_images_path(
+        self,
+        mock_get: Mock,
+        translator: Translator,
+        mock_images_response_posters: dict[str, Any],
+    ) -> None:
+        """Test movie artwork uses movie images endpoint."""
+        mock_get.return_value.json.return_value = mock_images_response_posters
+        mock_get.return_value.raise_for_status = Mock()
+
+        result = translator.select_best_image(
+            TmdbIds(tmdb_id=550, media_type="movie"), ["en-US"], kind="poster"
+        )
+
+        mock_get.assert_called_once_with("/movie/550/images", params=None)
+        assert result is not None
+        assert result.file_path == "/poster_en_us.jpg"
 
     @patch("httpx.Client.get")
     def test_select_best_image_season_poster(
@@ -1160,7 +1223,7 @@ class TestSelectBestImage:
         mock_get.return_value.json.return_value = season_response
         mock_get.return_value.raise_for_status = Mock()
 
-        tmdb_ids = TmdbIds(series_id=12345, season=1, episode=None)
+        tmdb_ids = TmdbIds(tmdb_id=12345, season=1)
         result = translator.select_best_image(tmdb_ids, ["en-US"], kind="poster")
 
         # Verify correct endpoint was called
@@ -1182,7 +1245,7 @@ class TestSelectBestImage:
         mock_get.return_value.json.return_value = mock_images_response_posters
         mock_get.return_value.raise_for_status = Mock()
 
-        tmdb_ids = TmdbIds(series_id=12345, season=None, episode=None)
+        tmdb_ids = TmdbIds(tmdb_id=12345, season=None, episode=None)
         # Prefer en-US first, then ja-JP
         result = translator.select_best_image(
             tmdb_ids, ["en-US", "ja-JP", "zh-CN"], kind="poster"
@@ -1205,7 +1268,7 @@ class TestSelectBestImage:
         mock_get.return_value.json.return_value = mock_images_response_posters
         mock_get.return_value.raise_for_status = Mock()
 
-        tmdb_ids = TmdbIds(series_id=12345, season=None, episode=None)
+        tmdb_ids = TmdbIds(tmdb_id=12345, season=None, episode=None)
         # Request fr-FR which doesn't exist in response
         result = translator.select_best_image(tmdb_ids, ["fr-FR"], kind="poster")
 
@@ -1239,7 +1302,7 @@ class TestSelectBestImage:
         mock_get.return_value.json.return_value = response_with_nulls
         mock_get.return_value.raise_for_status = Mock()
 
-        tmdb_ids = TmdbIds(series_id=12345, season=None, episode=None)
+        tmdb_ids = TmdbIds(tmdb_id=12345, season=None, episode=None)
         result = translator.select_best_image(tmdb_ids, ["en-US"], kind="poster")
 
         assert result is not None
@@ -1257,7 +1320,7 @@ class TestSelectBestImage:
         mock_get.return_value.json.return_value = mock_images_response_posters
         mock_get.return_value.raise_for_status = Mock()
 
-        tmdb_ids = TmdbIds(series_id=12345, season=None, episode=None)
+        tmdb_ids = TmdbIds(tmdb_id=12345, season=None, episode=None)
         # Malformed codes without hyphen should be skipped
         result = translator.select_best_image(
             tmdb_ids, ["en", "US", "en-US"], kind="poster"
@@ -1282,7 +1345,7 @@ class TestSelectBestImage:
         )
         mock_get.side_effect = not_found_error
 
-        tmdb_ids = TmdbIds(series_id=99999, season=None, episode=None)
+        tmdb_ids = TmdbIds(tmdb_id=99999, season=None, episode=None)
         result = translator.select_best_image(tmdb_ids, ["en-US"], kind="poster")
 
         assert result is None
@@ -1298,7 +1361,7 @@ class TestSelectBestImage:
         mock_get.return_value.json.return_value = mock_images_response_posters
         mock_get.return_value.raise_for_status = Mock()
 
-        tmdb_ids = TmdbIds(series_id=12345, season=None, episode=None)
+        tmdb_ids = TmdbIds(tmdb_id=12345, season=None, episode=None)
 
         # First call
         result1 = translator.select_best_image(tmdb_ids, ["en-US"], kind="poster")
@@ -1321,7 +1384,7 @@ class TestSelectBestImage:
         mock_get.return_value.json.return_value = empty_response
         mock_get.return_value.raise_for_status = Mock()
 
-        tmdb_ids = TmdbIds(series_id=12345, season=None, episode=None)
+        tmdb_ids = TmdbIds(tmdb_id=12345, season=None, episode=None)
         result = translator.select_best_image(tmdb_ids, ["en-US"], kind="poster")
 
         assert result is None
@@ -1343,7 +1406,7 @@ class TestSelectBestImage:
         mock_get.return_value.json.return_value = response_en_gb
         mock_get.return_value.raise_for_status = Mock()
 
-        tmdb_ids = TmdbIds(series_id=12345, season=None, episode=None)
+        tmdb_ids = TmdbIds(tmdb_id=12345, season=None, episode=None)
         result = translator.select_best_image(tmdb_ids, ["en-GB"], kind="poster")
         assert result is not None
         assert result.iso_639_1 == "en"
@@ -1402,7 +1465,7 @@ class TestSelectBestImage:
         mock_get.return_value.json.return_value = mock_images_response_posters
         mock_get.return_value.raise_for_status = Mock()
 
-        tmdb_ids = TmdbIds(series_id=12345, season=None, episode=None)
+        tmdb_ids = TmdbIds(tmdb_id=12345, season=None, episode=None)
         # "banner" is not a valid kind
         result = translator.select_best_image(
             tmdb_ids,

--- a/tests/unit/test_translator.py
+++ b/tests/unit/test_translator.py
@@ -120,11 +120,11 @@ def test_translator_initialization(translator: Translator) -> None:
 def test_tmdb_ids_string_representation() -> None:
     """Test TmdbIds __str__ method."""
     # Series
-    series_ids = TmdbIds(tmdb_id=12345)
+    series_ids = TmdbIds(tmdb_id=12345, media_type="tv")
     assert str(series_ids) == "tv/12345"
 
     # Episode
-    episode_ids = TmdbIds(tmdb_id=12345, season=1, episode=2)
+    episode_ids = TmdbIds(tmdb_id=12345, media_type="tv", season=1, episode=2)
     assert str(episode_ids) == "tv/12345/season/1/episode/2"
 
 
@@ -139,7 +139,7 @@ def test_get_translations_series_success(
     mock_response.json.return_value = mock_series_response
     mock_get.return_value = mock_response
 
-    tmdb_ids = TmdbIds(tmdb_id=12345)
+    tmdb_ids = TmdbIds(tmdb_id=12345, media_type="tv")
     translations = translator.get_translations(tmdb_ids)
 
     # Verify API call
@@ -185,7 +185,7 @@ def test_get_translations_episode_success(
     mock_response.json.return_value = mock_episode_response
     mock_get.return_value = mock_response
 
-    tmdb_ids = TmdbIds(tmdb_id=12345, season=1, episode=2)
+    tmdb_ids = TmdbIds(tmdb_id=12345, media_type="tv", season=1, episode=2)
     translations = translator.get_translations(tmdb_ids)
 
     # Verify API call with correct endpoint
@@ -236,7 +236,7 @@ def test_get_translations_http_error(mock_get: Mock, translator: Translator) -> 
     # Mock HTTP error
     mock_get.side_effect = httpx.HTTPError("API error")
 
-    tmdb_ids = TmdbIds(tmdb_id=12345)
+    tmdb_ids = TmdbIds(tmdb_id=12345, media_type="tv")
 
     # Should raise the HTTP error (fail-fast)
     with pytest.raises(httpx.HTTPError, match="API error"):
@@ -254,7 +254,7 @@ def test_get_translations_json_decode_error(
     mock_response.json.side_effect = json.JSONDecodeError("Invalid JSON", "doc", 0)
     mock_get.return_value = mock_response
 
-    tmdb_ids = TmdbIds(tmdb_id=12345)
+    tmdb_ids = TmdbIds(tmdb_id=12345, media_type="tv")
 
     # Should raise the JSON decode error (fail-fast)
     with pytest.raises(json.JSONDecodeError, match="Invalid JSON"):
@@ -272,7 +272,7 @@ def test_get_translations_empty_response(
     mock_response.json.return_value = {"id": 12345, "translations": []}
     mock_get.return_value = mock_response
 
-    tmdb_ids = TmdbIds(tmdb_id=12345)
+    tmdb_ids = TmdbIds(tmdb_id=12345, media_type="tv")
     translations = translator.get_translations(tmdb_ids)
 
     # Should return empty dict when no translations available
@@ -305,7 +305,7 @@ def test_get_translations_filters_empty_data(
     }
     mock_get.return_value = mock_response
 
-    tmdb_ids = TmdbIds(tmdb_id=12345)
+    tmdb_ids = TmdbIds(tmdb_id=12345, media_type="tv")
     translations = translator.get_translations(tmdb_ids)
 
     # Should only include translations with content
@@ -318,7 +318,7 @@ def test_cache_functionality(
     translator: Translator, mock_series_response: dict[str, Any]
 ) -> None:
     """Test DiskCache functionality."""
-    tmdb_ids = TmdbIds(tmdb_id=12345)
+    tmdb_ids = TmdbIds(tmdb_id=12345, media_type="tv")
     cache_key = f"translations:{tmdb_ids}/translations"
 
     # Verify cache starts empty
@@ -345,7 +345,7 @@ def test_caching_integration(
     mock_response.json.return_value = mock_series_response
     mock_get.return_value = mock_response
 
-    tmdb_ids = TmdbIds(tmdb_id=12345)
+    tmdb_ids = TmdbIds(tmdb_id=12345, media_type="tv")
 
     # First call should hit API and cache result
     translations1 = translator.get_translations(tmdb_ids)
@@ -387,7 +387,7 @@ def test_get_original_details_series_success(
     mock_response.json.return_value = mock_series_details_response
     mock_get.return_value = mock_response
 
-    tmdb_ids = TmdbIds(tmdb_id=68034)
+    tmdb_ids = TmdbIds(tmdb_id=68034, media_type="tv")
     result = translator.get_original_details(tmdb_ids)
 
     # Verify API call
@@ -441,7 +441,7 @@ def test_get_original_details_episode_success(
 
     mock_get.side_effect = mock_side_effect
 
-    tmdb_ids = TmdbIds(tmdb_id=12345, season=1, episode=1)
+    tmdb_ids = TmdbIds(tmdb_id=12345, media_type="tv", season=1, episode=1)
     result = translator.get_original_details(tmdb_ids)
 
     # Verify both API calls were made
@@ -468,7 +468,7 @@ def test_get_original_details_http_error(
     # Mock HTTP error
     mock_get.side_effect = httpx.HTTPError("API error")
 
-    tmdb_ids = TmdbIds(tmdb_id=12345)
+    tmdb_ids = TmdbIds(tmdb_id=12345, media_type="tv")
 
     # Should raise the HTTP error (fail-fast behavior with new implementation)
     with pytest.raises(httpx.HTTPError, match="API error"):
@@ -490,7 +490,7 @@ def test_get_original_details_missing_data(
     }
     mock_get.return_value = mock_response
 
-    tmdb_ids = TmdbIds(tmdb_id=12345)
+    tmdb_ids = TmdbIds(tmdb_id=12345, media_type="tv")
     result = translator.get_original_details(tmdb_ids)
 
     # Should return None when required data is missing
@@ -508,7 +508,7 @@ def test_get_original_details_caching(
     mock_response.json.return_value = mock_series_details_response
     mock_get.return_value = mock_response
 
-    tmdb_ids = TmdbIds(tmdb_id=68034)
+    tmdb_ids = TmdbIds(tmdb_id=68034, media_type="tv")
 
     # First call should hit API and cache result
     result1 = translator.get_original_details(tmdb_ids)
@@ -544,7 +544,7 @@ def test_rate_limit_retry_success(
 
     mock_get.side_effect = [rate_limit_error, success_response]
 
-    tmdb_ids = TmdbIds(tmdb_id=12345)
+    tmdb_ids = TmdbIds(tmdb_id=12345, media_type="tv")
     translations = translator.get_translations(tmdb_ids)
 
     # Should have made 2 API calls (1 failed, 1 success)
@@ -572,7 +572,7 @@ def test_rate_limit_max_retries_exceeded(
     )
     mock_get.side_effect = rate_limit_error
 
-    tmdb_ids = TmdbIds(tmdb_id=12345)
+    tmdb_ids = TmdbIds(tmdb_id=12345, media_type="tv")
 
     # Should raise the rate limit error after exhausting retries
     with pytest.raises(httpx.HTTPStatusError, match="Too Many Requests"):
@@ -603,7 +603,7 @@ def test_non_rate_limit_http_error_no_retry(
     )
     mock_get.side_effect = server_error
 
-    tmdb_ids = TmdbIds(tmdb_id=12345)
+    tmdb_ids = TmdbIds(tmdb_id=12345, media_type="tv")
 
     # Should raise the error immediately without retries
     with pytest.raises(httpx.HTTPStatusError, match="Internal Server Error"):
@@ -634,7 +634,7 @@ def test_rate_limit_exponential_backoff_max_delay(
         )
         mock_get.side_effect = rate_limit_error
 
-        tmdb_ids = TmdbIds(tmdb_id=12345)
+        tmdb_ids = TmdbIds(tmdb_id=12345, media_type="tv")
 
         with pytest.raises(httpx.HTTPStatusError):
             translator.get_translations(tmdb_ids)
@@ -662,7 +662,7 @@ def test_rate_limit_preserves_cache_on_failure(
     )
     mock_get.side_effect = rate_limit_error
 
-    tmdb_ids = TmdbIds(tmdb_id=12345)
+    tmdb_ids = TmdbIds(tmdb_id=12345, media_type="tv")
     cache_key = f"translations:{tmdb_ids}"
 
     # Ensure cache is empty initially
@@ -926,7 +926,7 @@ def test_get_translations_cache_backward_compatibility_integration(
     )
 
     # Manually set old format data in cache to simulate pre-upgrade cache
-    tmdb_ids = TmdbIds(tmdb_id=12345)
+    tmdb_ids = TmdbIds(tmdb_id=12345, media_type="tv")
     cache_key = f"translations:{tmdb_ids}"
     translator.cache.set(cache_key, {"zh-CN": old_cached_content})
 
@@ -994,7 +994,7 @@ def test_get_translations_404_cached(mock_get: Mock, translator: Translator) -> 
     )
     mock_get.side_effect = not_found_error
 
-    tmdb_ids = TmdbIds(tmdb_id=99999)  # Non-existent series
+    tmdb_ids = TmdbIds(tmdb_id=99999, media_type="tv")  # Non-existent series
     cache_key = f"translations:{tmdb_ids}"
 
     # Verify cache starts empty
@@ -1031,7 +1031,7 @@ def test_get_original_details_404_cached(
     )
     mock_get.side_effect = not_found_error
 
-    tmdb_ids = TmdbIds(tmdb_id=99999)  # Non-existent series
+    tmdb_ids = TmdbIds(tmdb_id=99999, media_type="tv")  # Non-existent series
     cache_key = f"original_details:{tmdb_ids}"
 
     # Verify cache starts empty
@@ -1155,7 +1155,7 @@ class TestSelectBestImage:
         mock_get.return_value.json.return_value = mock_images_response_posters
         mock_get.return_value.raise_for_status = Mock()
 
-        tmdb_ids = TmdbIds(tmdb_id=12345, season=None, episode=None)
+        tmdb_ids = TmdbIds(tmdb_id=12345, media_type="tv", season=None, episode=None)
         result = translator.select_best_image(tmdb_ids, ["en-US"], kind="poster")
 
         assert result is not None
@@ -1174,7 +1174,7 @@ class TestSelectBestImage:
         mock_get.return_value.json.return_value = mock_images_response_logos
         mock_get.return_value.raise_for_status = Mock()
 
-        tmdb_ids = TmdbIds(tmdb_id=67890, season=None, episode=None)
+        tmdb_ids = TmdbIds(tmdb_id=67890, media_type="tv", season=None, episode=None)
         result = translator.select_best_image(tmdb_ids, ["ja-JP"], kind="clearlogo")
 
         assert result is not None
@@ -1223,7 +1223,7 @@ class TestSelectBestImage:
         mock_get.return_value.json.return_value = season_response
         mock_get.return_value.raise_for_status = Mock()
 
-        tmdb_ids = TmdbIds(tmdb_id=12345, season=1)
+        tmdb_ids = TmdbIds(tmdb_id=12345, media_type="tv", season=1)
         result = translator.select_best_image(tmdb_ids, ["en-US"], kind="poster")
 
         # Verify correct endpoint was called
@@ -1245,7 +1245,7 @@ class TestSelectBestImage:
         mock_get.return_value.json.return_value = mock_images_response_posters
         mock_get.return_value.raise_for_status = Mock()
 
-        tmdb_ids = TmdbIds(tmdb_id=12345, season=None, episode=None)
+        tmdb_ids = TmdbIds(tmdb_id=12345, media_type="tv", season=None, episode=None)
         # Prefer en-US first, then ja-JP
         result = translator.select_best_image(
             tmdb_ids, ["en-US", "ja-JP", "zh-CN"], kind="poster"
@@ -1268,7 +1268,7 @@ class TestSelectBestImage:
         mock_get.return_value.json.return_value = mock_images_response_posters
         mock_get.return_value.raise_for_status = Mock()
 
-        tmdb_ids = TmdbIds(tmdb_id=12345, season=None, episode=None)
+        tmdb_ids = TmdbIds(tmdb_id=12345, media_type="tv", season=None, episode=None)
         # Request fr-FR which doesn't exist in response
         result = translator.select_best_image(tmdb_ids, ["fr-FR"], kind="poster")
 
@@ -1302,7 +1302,7 @@ class TestSelectBestImage:
         mock_get.return_value.json.return_value = response_with_nulls
         mock_get.return_value.raise_for_status = Mock()
 
-        tmdb_ids = TmdbIds(tmdb_id=12345, season=None, episode=None)
+        tmdb_ids = TmdbIds(tmdb_id=12345, media_type="tv", season=None, episode=None)
         result = translator.select_best_image(tmdb_ids, ["en-US"], kind="poster")
 
         assert result is not None
@@ -1320,7 +1320,7 @@ class TestSelectBestImage:
         mock_get.return_value.json.return_value = mock_images_response_posters
         mock_get.return_value.raise_for_status = Mock()
 
-        tmdb_ids = TmdbIds(tmdb_id=12345, season=None, episode=None)
+        tmdb_ids = TmdbIds(tmdb_id=12345, media_type="tv", season=None, episode=None)
         # Malformed codes without hyphen should be skipped
         result = translator.select_best_image(
             tmdb_ids, ["en", "US", "en-US"], kind="poster"
@@ -1345,7 +1345,7 @@ class TestSelectBestImage:
         )
         mock_get.side_effect = not_found_error
 
-        tmdb_ids = TmdbIds(tmdb_id=99999, season=None, episode=None)
+        tmdb_ids = TmdbIds(tmdb_id=99999, media_type="tv", season=None, episode=None)
         result = translator.select_best_image(tmdb_ids, ["en-US"], kind="poster")
 
         assert result is None
@@ -1361,7 +1361,7 @@ class TestSelectBestImage:
         mock_get.return_value.json.return_value = mock_images_response_posters
         mock_get.return_value.raise_for_status = Mock()
 
-        tmdb_ids = TmdbIds(tmdb_id=12345, season=None, episode=None)
+        tmdb_ids = TmdbIds(tmdb_id=12345, media_type="tv", season=None, episode=None)
 
         # First call
         result1 = translator.select_best_image(tmdb_ids, ["en-US"], kind="poster")
@@ -1384,7 +1384,7 @@ class TestSelectBestImage:
         mock_get.return_value.json.return_value = empty_response
         mock_get.return_value.raise_for_status = Mock()
 
-        tmdb_ids = TmdbIds(tmdb_id=12345, season=None, episode=None)
+        tmdb_ids = TmdbIds(tmdb_id=12345, media_type="tv", season=None, episode=None)
         result = translator.select_best_image(tmdb_ids, ["en-US"], kind="poster")
 
         assert result is None
@@ -1406,7 +1406,7 @@ class TestSelectBestImage:
         mock_get.return_value.json.return_value = response_en_gb
         mock_get.return_value.raise_for_status = Mock()
 
-        tmdb_ids = TmdbIds(tmdb_id=12345, season=None, episode=None)
+        tmdb_ids = TmdbIds(tmdb_id=12345, media_type="tv", season=None, episode=None)
         result = translator.select_best_image(tmdb_ids, ["en-GB"], kind="poster")
         assert result is not None
         assert result.iso_639_1 == "en"
@@ -1465,7 +1465,7 @@ class TestSelectBestImage:
         mock_get.return_value.json.return_value = mock_images_response_posters
         mock_get.return_value.raise_for_status = Mock()
 
-        tmdb_ids = TmdbIds(tmdb_id=12345, season=None, episode=None)
+        tmdb_ids = TmdbIds(tmdb_id=12345, media_type="tv", season=None, episode=None)
         # "banner" is not a valid kind
         result = translator.select_best_image(
             tmdb_ids,

--- a/vulture_whitelist.py
+++ b/vulture_whitelist.py
@@ -26,7 +26,7 @@ _.frame
 _.description
 _.file_modified
 _.file_path
-_.series_id
+_.tmdb_id
 _.translated_content
 _.selected_language
 _.selected_file_path


### PR DESCRIPTION
Localize Radarr movie metadata and artwork through the same language-preference pipeline already used for Sonarr TV.

The service now watches Radarr-generated `<movie>` NFO files, fetches translations via `/movie/{id}/translations`, and rewrites movie posters and clearlogos to match the preferred language list. This addresses the Radarr artwork language gap described in [Radarr #9863](https://github.com/Radarr/Radarr/issues/9863), [Radarr #5277](https://github.com/Radarr/Radarr/issues/5277), and [Radarr #8025](https://github.com/Radarr/Radarr/issues/8025).

Movie NFOs without a TMDB ID are skipped. Existing Sonarr TV behavior is unchanged.

See [design doc](../blob/feat/radarr-movie-support/docs/design/radarr-movie-support.md) for details.