### PR TITLE
[test] enforce zero code duplication

### DIFF
--- a/.jscpd.json
+++ b/.jscpd.json
@@ -1,0 +1,7 @@
+{
+  "ignore": [".agents/**"],
+  "minLines": 5,
+  "threshold": 0,
+  "reporters": ["ai"],
+  "noTips": true
+}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,6 +21,13 @@ repos:
         language: system
         pass_filenames: false
 
+      # Duplication check
+      - id: duplication
+        name: Duplication Check
+        entry: npx --yes jscpd
+        language: system
+        pass_filenames: false
+
   # Standard pre-commit hooks
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.6.0

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,9 @@ echo "TMDB_API_KEY=your_api_key_here" > .env
 
 # Combine coverage from unit and integration tests
 ./scripts/combine-coverage.sh
+
+# Run duplication scan
+npx jscpd
 ```
 
 ### Development Usage
@@ -193,6 +196,7 @@ development fallback.
 - **Integration Testing**: Docker/Podman-based Sonarr and Radarr integration
   tests
 - **Dead Code**: Vulture with whitelist support
+- **Duplication**: jscpd for copy-paste detection
 - **Automation**: pre-commit hooks for all quality checks
 
 ### File Structure

--- a/README.md
+++ b/README.md
@@ -54,13 +54,19 @@ the [TMDB Authentication Guide](https://developer.themoviedb.org/docs/authentica
 
 **Docker (recommended):**
 
+Create a configuration file:
+
+```dotenv
+TMDB_API_KEY=your_api_read_access_token_here
+REWRITE_ROOT_DIRS=/tv,/anime
+PREFERRED_LANGUAGES=zh-CN,ja-JP
+```
+
 ```bash
 docker run -d \
   --name sonarr-metadata-rewrite \
   --user $(id -u):$(id -g) \
-  -e TMDB_API_KEY=your_api_key_here \
-  -e REWRITE_ROOT_DIRS=/tv,/anime \
-  -e PREFERRED_LANGUAGES=zh-CN,ja-JP \
+  --env-file /path/to/sonarr-metadata-rewrite.env \
   -v /path/to/tv/shows:/tv \
   -v /path/to/anime:/anime \
   -v sonarr-metadata-cache:/app/cache \
@@ -78,12 +84,8 @@ services:
     image: kfstorm/sonarr-metadata-rewrite:latest
     container_name: sonarr-metadata-rewrite
     user: "${UID:-1000}:${GID:-1000}"
-    environment:
-      - TMDB_API_KEY=your_api_key_here
-      - REWRITE_ROOT_DIRS=/tv,/anime
-      - PREFERRED_LANGUAGES=zh-CN,ja-JP
-      # Optional: customize cache duration (default: 30 days)
-      # - CACHE_DURATION_HOURS=168
+    env_file:
+      - /path/to/sonarr-metadata-rewrite.env
     volumes:
       - /path/to/tv/shows:/tv
       - /path/to/anime:/anime
@@ -307,13 +309,13 @@ Set the service to rollback mode, which will restore all original files from bac
 
 **Docker:**
 
+Use same configuration file as your running rewrite service:
+
 ```bash
 docker run --rm \
   --user $(id -u):$(id -g) \
   -e SERVICE_MODE=rollback \
-  -e TMDB_API_KEY=your_api_key_here \
-  -e REWRITE_ROOT_DIRS=/tv,/anime \
-  -e PREFERRED_LANGUAGES=zh-CN,ja-JP \
+  --env-file /path/to/sonarr-metadata-rewrite.env \
   -v /path/to/tv/shows:/tv \
   -v /path/to/anime:/anime \
   -v sonarr-metadata-backups:/app/backups \
@@ -352,7 +354,11 @@ Want to hack on this? Cool!
 git clone https://github.com/kfstorm/sonarr-metadata-rewrite.git
 cd sonarr-metadata-rewrite
 ./scripts/setup-dev.sh
-echo "TMDB_API_KEY=your_key" > .env
+cat > .env <<'EOF'
+TMDB_API_KEY=your_api_read_access_token_here
+REWRITE_ROOT_DIRS=/path/to/tv/shows,/path/to/anime
+PREFERRED_LANGUAGES=zh-CN,ja-JP
+EOF
 ```
 
 **Run tests:**

--- a/src/sonarr_metadata_rewrite/metadata_processor.py
+++ b/src/sonarr_metadata_rewrite/metadata_processor.py
@@ -95,42 +95,18 @@ class MetadataProcessor:
                         ),
                     )
                 else:
-                    preferred_langs = ", ".join(self.settings.preferred_languages)
-                    available_langs = (
-                        ", ".join(sorted(all_translations.keys()))
-                        if all_translations
-                        else "none"
-                    )
-                    return MetadataProcessResult(
-                        success=False,
-                        file_path=nfo_path,
-                        message=(
-                            f"File unchanged - content already matches original and "
-                            f"no translation available in preferred languages "
-                            f"[{preferred_langs}]. "
-                            f"Available: [{available_langs}]"
-                        ),
-                        tmdb_ids=tmdb_ids,
-                        file_modified=False,
-                        translated_content=None,
+                    return self._build_no_translation_result(
+                        nfo_path,
+                        tmdb_ids,
+                        all_translations,
+                        content_matches_original=True,
                     )
             else:
-                preferred_langs = ", ".join(self.settings.preferred_languages)
-                available_langs = (
-                    ", ".join(sorted(all_translations.keys()))
-                    if all_translations
-                    else "none"
-                )
-                return MetadataProcessResult(
-                    success=False,
-                    file_path=nfo_path,
-                    message=(
-                        f"File unchanged - no translation available in preferred "
-                        f"languages [{preferred_langs}]. Available: [{available_langs}]"
-                    ),
-                    tmdb_ids=tmdb_ids,
-                    file_modified=False,
-                    translated_content=None,
+                return self._build_no_translation_result(
+                    nfo_path,
+                    tmdb_ids,
+                    all_translations,
+                    content_matches_original=False,
                 )
 
         selected_translation = self._apply_fallback_to_translation(
@@ -168,6 +144,33 @@ class MetadataProcessor:
             backup_created=backup_created,
             file_modified=True,
             translated_content=selected_translation,
+        )
+
+    def _build_no_translation_result(
+        self,
+        nfo_path: Path,
+        tmdb_ids: TmdbIds,
+        all_translations: dict[str, TranslatedContent],
+        *,
+        content_matches_original: bool,
+    ) -> MetadataProcessResult:
+        """Build a result for an unchanged file without a preferred translation."""
+        preferred_langs = ", ".join(self.settings.preferred_languages)
+        available_langs = ", ".join(sorted(all_translations)) or "none"
+        original_match_message = (
+            "content already matches original and " if content_matches_original else ""
+        )
+        return MetadataProcessResult(
+            success=False,
+            file_path=nfo_path,
+            message=(
+                f"File unchanged - {original_match_message}no translation available "
+                f"in preferred languages [{preferred_langs}]. "
+                f"Available: [{available_langs}]"
+            ),
+            tmdb_ids=tmdb_ids,
+            file_modified=False,
+            translated_content=None,
         )
 
     def _process_episode_file(

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -4,6 +4,7 @@ import os
 import socket
 import tempfile
 from collections.abc import Generator
+from contextlib import contextmanager
 from pathlib import Path
 
 import pytest
@@ -36,25 +37,82 @@ def _write_arr_config(config_dir: Path, port: int, instance_name: str) -> None:
 </Config>""")
 
 
+@contextmanager
+def _temporary_arr_config(
+    prefix: str, port: int, instance_name: str
+) -> Generator[Path, None, None]:
+    """Create temporary Arr config with common LinuxServer settings."""
+    with tempfile.TemporaryDirectory(prefix=prefix) as temp_dir:
+        config_dir = Path(temp_dir)
+        _write_arr_config(config_dir, port, instance_name)
+        yield config_dir
+
+
+def _find_free_port() -> int:
+    """Reserve an available local TCP port number."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as socket_handle:
+        socket_handle.bind(("", 0))
+        return socket_handle.getsockname()[1]
+
+
+def _arr_environment() -> dict[str, str]:
+    """Return LinuxServer container user and timezone settings."""
+    return {
+        "TZ": "UTC",
+        "PUID": str(os.getuid()),
+        "PGID": str(os.getgid()),
+    }
+
+
+def _arr_extra_args(container_manager: ContainerManager) -> list[str]:
+    """Return container runtime-specific arguments for Arr images."""
+    return ["--userns=keep-id"] if container_manager.runtime == "podman" else []
+
+
+def _start_arr_container(
+    container_manager: ContainerManager,
+    image: str,
+    name_prefix: str,
+    container_port: int,
+    media_root: Path,
+    media_path: str,
+    config_dir: Path,
+) -> int:
+    """Start an Arr container and return its mapped local port."""
+    free_port = _find_free_port()
+    container_manager.run_container(
+        image=image,
+        name=f"{name_prefix}-{free_port}",
+        ports={container_port: free_port},
+        volumes={
+            str(media_root): media_path,
+            str(config_dir): "/config",
+        },
+        environment=_arr_environment(),
+        extra_args=_arr_extra_args(container_manager),
+    )
+    return free_port
+
+
 @pytest.fixture(scope="session")
-def temp_media_root() -> Generator[Path, None, None]:
-    """Create session-wide temporary media directory for Sonarr container and tests."""
+def temp_sonarr_media_root() -> Generator[Path, None, None]:
+    """Create session-wide temporary media directory for Sonarr tests."""
     with tempfile.TemporaryDirectory(prefix="sonarr_media_") as temp_dir:
         yield Path(temp_dir)
 
 
 @pytest.fixture(scope="session")
-def temp_config_dir() -> Generator[Path, None, None]:
-    """Create temporary config directory for Sonarr container."""
-    with tempfile.TemporaryDirectory(prefix="sonarr_config_") as temp_dir:
-        temp_path = Path(temp_dir)
+def temp_radarr_media_root() -> Generator[Path, None, None]:
+    """Create session-wide temporary media directory for Radarr tests."""
+    with tempfile.TemporaryDirectory(prefix="radarr_media_") as temp_dir:
+        yield Path(temp_dir)
 
-        _write_arr_config(
-            temp_path,
-            port=8989,
-            instance_name="Sonarr (Test)",
-        )
-        yield temp_path
+
+@pytest.fixture(scope="session")
+def temp_sonarr_config_dir() -> Generator[Path, None, None]:
+    """Create temporary config directory for Sonarr container."""
+    with _temporary_arr_config("sonarr_config_", 8989, "Sonarr (Test)") as config_dir:
+        yield config_dir
 
 
 @pytest.fixture(scope="session")
@@ -67,41 +125,18 @@ def container_manager() -> Generator[ContainerManager, None, None]:
 @pytest.fixture(scope="session")
 def sonarr_container(
     container_manager: ContainerManager,
-    temp_media_root: Path,
-    temp_config_dir: Path,
+    temp_sonarr_media_root: Path,
+    temp_sonarr_config_dir: Path,
 ) -> Generator[SonarrClient, None, None]:
     """Start Sonarr container and return configured client."""
-    # Find a free port
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-        s.bind(("", 0))
-        free_port = s.getsockname()[1]
-
-    # Always set PUID/PGID for LinuxServer images
-
-    env = {
-        "TZ": "UTC",
-        "PUID": str(os.getuid()),
-        "PGID": str(os.getgid()),
-    }
-
-    # Set container runtime-specific arguments
-    extra_args = []
-    if container_manager.runtime == "podman":
-        # Use keep-id to maintain consistent UID mapping with PUID/PGID
-        extra_args.append("--userns=keep-id")
-
-    # Start Sonarr container (runs in foreground with output streaming)
-    container_name = f"sonarr-test-{free_port}"
-    container_manager.run_container(
+    free_port = _start_arr_container(
+        container_manager,
         image="docker.io/linuxserver/sonarr:latest",
-        name=container_name,
-        ports={8989: free_port},
-        volumes={
-            str(temp_media_root): "/tv",
-            str(temp_config_dir): "/config",
-        },
-        environment=env,
-        extra_args=extra_args,
+        name_prefix="sonarr-test",
+        container_port=8989,
+        media_root=temp_sonarr_media_root,
+        media_path="/tv",
+        config_dir=temp_sonarr_config_dir,
     )
 
     # Create and configure client with the API key from our config
@@ -136,38 +171,25 @@ def configured_sonarr_container(sonarr_container: SonarrClient) -> SonarrClient:
 @pytest.fixture(scope="session")
 def temp_radarr_config_dir() -> Generator[Path, None, None]:
     """Create temporary config directory for Radarr container."""
-    with tempfile.TemporaryDirectory(prefix="radarr_config_") as temp_dir:
-        temp_path = Path(temp_dir)
-        _write_arr_config(temp_path, port=7878, instance_name="Radarr (Test)")
-        yield temp_path
+    with _temporary_arr_config("radarr_config_", 7878, "Radarr (Test)") as config_dir:
+        yield config_dir
 
 
 @pytest.fixture(scope="session")
 def radarr_container(
-    temp_media_root: Path,
+    temp_radarr_media_root: Path,
     temp_radarr_config_dir: Path,
 ) -> Generator[RadarrClient, None, None]:
     """Start Radarr container and return configured client."""
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
-        sock.bind(("", 0))
-        free_port = sock.getsockname()[1]
-
     with ContainerManager() as manager:
-        extra_args = ["--userns=keep-id"] if manager.runtime == "podman" else []
-        manager.run_container(
+        free_port = _start_arr_container(
+            manager,
             image="docker.io/linuxserver/radarr:latest",
-            name=f"radarr-test-{free_port}",
-            ports={7878: free_port},
-            volumes={
-                str(temp_media_root): "/movies",
-                str(temp_radarr_config_dir): "/config",
-            },
-            environment={
-                "TZ": "UTC",
-                "PUID": str(os.getuid()),
-                "PGID": str(os.getgid()),
-            },
-            extra_args=extra_args,
+            name_prefix="radarr-test",
+            container_port=7878,
+            media_root=temp_radarr_media_root,
+            media_path="/movies",
+            config_dir=temp_radarr_config_dir,
         )
         client = RadarrClient(f"http://localhost:{free_port}", api_key=TEST_API_KEY)
         if not client.wait_for_ready(max_attempts=30, delay=1.0):

--- a/tests/integration/fixtures/arr_client.py
+++ b/tests/integration/fixtures/arr_client.py
@@ -1,12 +1,18 @@
 """Shared HTTP client support for Arr integration fixtures."""
 
+import time
+from pathlib import Path
 from typing import Any
 
 import httpx
 
+from sonarr_metadata_rewrite.retry_utils import retry
+
 
 class ArrClient:
     """Authenticated HTTP client shared by Sonarr and Radarr test fixtures."""
+
+    service_name: str
 
     def __init__(self, base_url: str, api_key: str | None = None):
         self.base_url = base_url.rstrip("/")
@@ -21,6 +27,57 @@ class ArrClient:
             params = kwargs.setdefault("params", {})
             params["apikey"] = self.api_key
         return self.client.request(method, f"{self.base_url}{endpoint}", **kwargs)
+
+    def wait_for_ready(self, max_attempts: int = 30, delay: float = 1.0) -> bool:
+        """Wait for Arr API readiness."""
+        timeout_sec = max_attempts * delay
+        print(
+            f"Waiting for {self.service_name} at {self.base_url} "
+            f"(max {timeout_sec:.1f}s timeout)"
+        )
+
+        @retry(
+            timeout=timeout_sec,
+            interval=delay,
+            log_interval=5.0,
+            exceptions=(httpx.RequestError, httpx.HTTPStatusError),
+        )
+        def check_status() -> bool:
+            response = self._make_request("GET", "/api/v3/system/status", timeout=5.0)
+            response.raise_for_status()
+            return True
+
+        try:
+            result = check_status()
+            print(f"{self.service_name} is ready")
+            return result
+        except Exception as exc:
+            print(f"{self.service_name} failed to become ready: {exc}")
+            return False
+
+    def _wait_for_directory_removal(
+        self, directory: Path, resource_name: str, timeout: float
+    ) -> bool:
+        """Wait for Arr to remove a resource directory."""
+        start_time = time.time()
+        while time.time() - start_time < timeout:
+            if not directory.exists():
+                return True
+            time.sleep(1)
+            elapsed = time.time() - start_time
+            if elapsed % 5 == 0:
+                print(
+                    f"Still waiting for {resource_name.lower()} directory removal... "
+                    f"({elapsed:.1f}s elapsed)"
+                )
+
+        if directory.exists():
+            remaining_files = list(directory.rglob("*"))
+            raise RuntimeError(
+                f"{resource_name} directory {directory} still exists after {timeout}s. "
+                f"Remaining files: {remaining_files}"
+            )
+        return True
 
     def close(self) -> None:
         """Close the HTTP client."""

--- a/tests/integration/fixtures/movie_manager.py
+++ b/tests/integration/fixtures/movie_manager.py
@@ -43,9 +43,7 @@ class MovieManager:
         if self.movie_data is None:
             return
         try:
-            self.radarr_client.remove_movie(
-                self.id, self.temp_media_root, self.directory
-            )
+            self.radarr_client.remove_movie(self.id, self.directory)
         except Exception as exc:
             print(f"Error during movie cleanup: {exc}")
 

--- a/tests/integration/fixtures/radarr_client.py
+++ b/tests/integration/fixtures/radarr_client.py
@@ -1,38 +1,15 @@
 """Radarr API client for integration testing."""
 
-import time
 from pathlib import Path
 from typing import Any
 
-import httpx
-
-from sonarr_metadata_rewrite.retry_utils import retry
 from tests.integration.fixtures.arr_client import ArrClient
 
 
 class RadarrClient(ArrClient):
     """Small Radarr API client used by integration tests."""
 
-    def wait_for_ready(self, max_attempts: int = 30, delay: float = 1.0) -> bool:
-        """Wait for Radarr API readiness."""
-        timeout_sec = max_attempts * delay
-
-        @retry(
-            timeout=timeout_sec,
-            interval=delay,
-            log_interval=5.0,
-            exceptions=(httpx.RequestError, httpx.HTTPStatusError),
-        )
-        def check_status() -> bool:
-            response = self._make_request("GET", "/api/v3/system/status", timeout=5.0)
-            response.raise_for_status()
-            return True
-
-        try:
-            return check_status()
-        except Exception as exc:
-            print(f"Radarr failed to become ready: {exc}")
-            return False
+    service_name = "Radarr"
 
     def add_movie(
         self,
@@ -135,7 +112,6 @@ class RadarrClient(ArrClient):
     def remove_movie(
         self,
         movie_id: int,
-        media_root: Path,
         movie_directory: Path,
         timeout: float = 30.0,
     ) -> bool:
@@ -146,16 +122,4 @@ class RadarrClient(ArrClient):
         if not response.is_success:
             return False
 
-        start_time = time.time()
-        while time.time() - start_time < timeout:
-            if not movie_directory.exists():
-                return True
-            time.sleep(1)
-
-        if movie_directory.exists():
-            remaining_files = list(movie_directory.rglob("*"))
-            raise RuntimeError(
-                f"Movie directory {movie_directory} still exists after {timeout}s. "
-                f"Remaining files: {remaining_files}"
-            )
-        return True
+        return self._wait_for_directory_removal(movie_directory, "Movie", timeout)

--- a/tests/integration/fixtures/sonarr_client.py
+++ b/tests/integration/fixtures/sonarr_client.py
@@ -1,53 +1,15 @@
 """Sonarr API client for integration testing."""
 
-import time
 from pathlib import Path
 from typing import Any
 
-import httpx
-
-from sonarr_metadata_rewrite.retry_utils import retry
 from tests.integration.fixtures.arr_client import ArrClient
 
 
 class SonarrClient(ArrClient):
     """Simple Sonarr API client for integration tests."""
 
-    def wait_for_ready(self, max_attempts: int = 30, delay: float = 1.0) -> bool:
-        """Wait for Sonarr to be ready and responding."""
-        timeout_sec = max_attempts * delay
-        print(f"Waiting for Sonarr at {self.base_url} (max {timeout_sec:.1f}s timeout)")
-
-        @retry(
-            timeout=timeout_sec,
-            interval=delay,
-            log_interval=5.0,
-            exceptions=(httpx.RequestError, httpx.HTTPStatusError),
-        )
-        def check_sonarr_status() -> bool:
-            # Use API key if we have one
-            params = {}
-            if self.api_key:
-                params["apikey"] = self.api_key
-
-            response = self.client.get(
-                f"{self.base_url}/api/v3/system/status", params=params, timeout=5.0
-            )
-            if response.status_code != 200:
-                raise httpx.HTTPStatusError(
-                    f"HTTP {response.status_code}",
-                    request=response.request,
-                    response=response,
-                )
-            return True
-
-        try:
-            result = check_sonarr_status()
-            print("Sonarr is ready")
-            return result
-        except Exception as e:
-            print(f"Sonarr failed to become ready: {e}")
-            return False
+    service_name = "Sonarr"
 
     def add_series(
         self,
@@ -222,29 +184,5 @@ class SonarrClient(ArrClient):
 
         print(f"Series {series_id} deletion command sent successfully")
 
-        # Wait for series directory to be removed from filesystem
         series_dir = media_root / series_slug
-        start_time = time.time()
-
-        while time.time() - start_time < timeout:
-            if not series_dir.exists():
-                print(f"Series directory {series_dir} successfully removed")
-                return True
-
-            time.sleep(1)
-            elapsed = time.time() - start_time
-            if elapsed % 5 == 0:  # Log every 5 seconds
-                print(
-                    f"Still waiting for series directory removal... "
-                    f"({elapsed:.1f}s elapsed)"
-                )
-
-        # Directory still exists after timeout
-        if series_dir.exists():
-            remaining_files = list(series_dir.rglob("*"))
-            raise RuntimeError(
-                f"Series directory {series_dir} still exists after {timeout}s. "
-                f"Remaining files: {remaining_files}"
-            )
-
-        return True
+        return self._wait_for_directory_removal(series_dir, "Series", timeout)

--- a/tests/integration/test_radarr_integration.py
+++ b/tests/integration/test_radarr_integration.py
@@ -46,7 +46,7 @@ def verify_movie_output(nfo_file: Path, image_files: list[Path]) -> None:
     ],
 )
 def test_radarr_movie_metadata_and_images(
-    temp_media_root: Path,
+    temp_radarr_media_root: Path,
     radarr_container: RadarrClient,
     use_movie_nfo: bool,
     service_config: dict[str, str],
@@ -58,13 +58,13 @@ def test_radarr_movie_metadata_and_images(
 
     if service_config.get("ENABLE_FILE_SCANNER") == "false":
         with ServiceRunner(
-            temp_media_root,
+            temp_radarr_media_root,
             service_config,
             startup_pattern="File monitor started",
         ):
             with MovieWithNfos(
                 radarr_container,
-                temp_media_root,
+                temp_radarr_media_root,
                 FIGHT_CLUB_TMDB_ID,
                 use_movie_nfo,
             ) as (nfo_file, image_files):
@@ -72,9 +72,9 @@ def test_radarr_movie_metadata_and_images(
     else:
         with MovieWithNfos(
             radarr_container,
-            temp_media_root,
+            temp_radarr_media_root,
             FIGHT_CLUB_TMDB_ID,
             use_movie_nfo,
         ) as (nfo_file, image_files):
-            with ServiceRunner(temp_media_root, service_config):
+            with ServiceRunner(temp_radarr_media_root, service_config):
                 verify_movie_output(nfo_file, image_files)

--- a/tests/integration/test_sonarr_integration.py
+++ b/tests/integration/test_sonarr_integration.py
@@ -58,7 +58,7 @@ GEN_V_IMAGES = ["poster.jpg", "clearlogo.png"] + season_poster_image_filenames(
 @pytest.mark.integration
 @pytest.mark.slow
 def test_file_monitor_workflow(
-    temp_media_root: Path,
+    temp_sonarr_media_root: Path,
     configured_sonarr_container: SonarrClient,
 ) -> None:
     """Test file monitor-only workflow with real-time NFO and image processing.
@@ -67,14 +67,14 @@ def test_file_monitor_workflow(
     NFO files and images in real-time when they are created by Sonarr.
     """
     with ServiceRunner(
-        temp_media_root,
+        temp_sonarr_media_root,
         {"ENABLE_FILE_SCANNER": "false"},
         startup_pattern="File monitor started",
     ):
         # Service startup waits for "File monitor started" log, so no sleep needed
         with SeriesWithNfos(
             configured_sonarr_container,
-            temp_media_root,
+            temp_sonarr_media_root,
             BREAKING_BAD_TVDB_ID,
             BREAKING_BAD_IMAGES,
         ) as (nfo_files, image_files):
@@ -87,7 +87,7 @@ def test_file_monitor_workflow(
 @pytest.mark.integration
 @pytest.mark.slow
 def test_file_scanner_workflow(
-    temp_media_root: Path,
+    temp_sonarr_media_root: Path,
     configured_sonarr_container: SonarrClient,
 ) -> None:
     """Test file scanner-only workflow with periodic directory scanning.
@@ -97,11 +97,11 @@ def test_file_scanner_workflow(
     """
     with SeriesWithNfos(
         configured_sonarr_container,
-        temp_media_root,
+        temp_sonarr_media_root,
         BREAKING_BAD_TVDB_ID,
         BREAKING_BAD_IMAGES,
     ) as (nfo_files, image_files):
-        with ServiceRunner(temp_media_root, {"ENABLE_FILE_MONITOR": "false"}):
+        with ServiceRunner(temp_sonarr_media_root, {"ENABLE_FILE_MONITOR": "false"}):
             verify_translations(
                 nfo_files, expected_language="zh", possible_languages=["zh", "en"]
             )
@@ -111,7 +111,7 @@ def test_file_scanner_workflow(
 @pytest.mark.integration
 @pytest.mark.slow
 def test_rollback_service_mode(
-    temp_media_root: Path,
+    temp_sonarr_media_root: Path,
     configured_sonarr_container: SonarrClient,
     tmp_path: Path,
 ) -> None:
@@ -126,13 +126,13 @@ def test_rollback_service_mode(
 
     with SeriesWithNfos(
         configured_sonarr_container,
-        temp_media_root,
+        temp_sonarr_media_root,
         BREAKING_BAD_TVDB_ID,
         BREAKING_BAD_IMAGES,
     ) as (nfo_files, image_files):
         # First, translate files to Chinese using rewrite mode with backups enabled
         with ServiceRunner(
-            temp_media_root,
+            temp_sonarr_media_root,
             {
                 "ORIGINAL_FILES_BACKUP_DIR": str(backup_dir),
             },
@@ -144,7 +144,7 @@ def test_rollback_service_mode(
 
         # Then, rollback using rollback service mode
         with ServiceRunner(
-            temp_media_root,
+            temp_sonarr_media_root,
             {"SERVICE_MODE": "rollback", "ORIGINAL_FILES_BACKUP_DIR": str(backup_dir)},
         ):
             verify_translations(
@@ -157,7 +157,7 @@ def test_rollback_service_mode(
 @pytest.mark.integration
 @pytest.mark.slow
 def test_nfo_rewrite_disabled(
-    temp_media_root: Path,
+    temp_sonarr_media_root: Path,
     configured_sonarr_container: SonarrClient,
 ) -> None:
     """Test that NFO rewrite can be disabled independently of image rewriting.
@@ -168,12 +168,12 @@ def test_nfo_rewrite_disabled(
     """
     with SeriesWithNfos(
         configured_sonarr_container,
-        temp_media_root,
+        temp_sonarr_media_root,
         BREAKING_BAD_TVDB_ID,
         BREAKING_BAD_IMAGES,
     ) as (nfo_files, image_files):
         with ServiceRunner(
-            temp_media_root,
+            temp_sonarr_media_root,
             {"ENABLE_NFO_REWRITE": "false"},
         ):
             # Images should still be rewritten with zh-CN markers
@@ -216,7 +216,7 @@ def test_nfo_rewrite_disabled(
     ids=["translation-fallback", "external-id-lookup", "smart-fallback-merging"],
 )
 def test_advanced_translation_scenarios(
-    temp_media_root: Path,
+    temp_sonarr_media_root: Path,
     configured_sonarr_container: SonarrClient,
     tvdb_id: int,
     images: list[str],
@@ -237,12 +237,12 @@ def test_advanced_translation_scenarios(
         possible_languages.add("zh")
 
     with SeriesWithNfos(
-        configured_sonarr_container, temp_media_root, tvdb_id, images
+        configured_sonarr_container, temp_sonarr_media_root, tvdb_id, images
     ) as (
         nfo_files,
         _,
     ):
-        with ServiceRunner(temp_media_root, service_config):
+        with ServiceRunner(temp_sonarr_media_root, service_config):
             verify_translations(
                 nfo_files,
                 expected_language,
@@ -253,7 +253,7 @@ def test_advanced_translation_scenarios(
 @pytest.mark.integration
 @pytest.mark.slow
 def test_multi_episode_nfo_rewrite_and_rollback(
-    temp_media_root: Path,
+    temp_sonarr_media_root: Path,
     configured_sonarr_container: SonarrClient,
     tmp_path: Path,
 ) -> None:
@@ -265,10 +265,10 @@ def test_multi_episode_nfo_rewrite_and_rollback(
         configured_sonarr_container,
         BREAKING_BAD_TVDB_ID,
         "/tv",
-        temp_media_root,
+        temp_sonarr_media_root,
     ) as series:
         create_fake_multi_episode_file(
-            temp_media_root,
+            temp_sonarr_media_root,
             series.slug,
             season=1,
             first_episode=1,
@@ -279,7 +279,7 @@ def test_multi_episode_nfo_rewrite_and_rollback(
         scan_success = configured_sonarr_container.trigger_disk_scan(series.id)
         assert scan_success, "Failed to trigger disk scan"
 
-        series_path = temp_media_root / series.slug
+        series_path = temp_sonarr_media_root / series.slug
         nfo_files = wait_for_nfo_files(series_path, expected_count=2, timeout=30.0)
         multi_episode_nfos = [
             nfo_file for nfo_file in nfo_files if "E01-E02" in nfo_file.name
@@ -294,7 +294,7 @@ def test_multi_episode_nfo_rewrite_and_rollback(
         assert "</episodedetails>\n<episodedetails>" in original_content
 
         with ServiceRunner(
-            temp_media_root,
+            temp_sonarr_media_root,
             {
                 "ENABLE_FILE_MONITOR": "false",
                 "ORIGINAL_FILES_BACKUP_DIR": str(backup_dir),
@@ -310,7 +310,7 @@ def test_multi_episode_nfo_rewrite_and_rollback(
             assert "</episodedetails>\n<episodedetails>" in rewritten_content
 
         with ServiceRunner(
-            temp_media_root,
+            temp_sonarr_media_root,
             {
                 "SERVICE_MODE": "rollback",
                 "ENABLE_FILE_MONITOR": "false",

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -66,9 +66,9 @@ def patch_image_download_retry() -> Generator[None, None, None]:
     original_retry = sonarr_metadata_rewrite.image_processor.retry
 
     def fast_retry(
-        timeout: float = 15.0,
-        interval: float = 0.5,
-        log_interval: float = 2.0,
+        timeout: float = 0.2,
+        interval: float = 0.02,
+        log_interval: float = 0.1,
         exceptions: tuple[type[Exception], ...] = (Exception,),
     ) -> Callable[[Callable[[], Any]], Callable[[], Any]]:
         """Fast retry for tests with minimal timeout."""

--- a/tests/unit/test_backup_utils.py
+++ b/tests/unit/test_backup_utils.py
@@ -12,6 +12,22 @@ from sonarr_metadata_rewrite.backup_utils import (
 )
 
 
+def create_legacy_backup(backup_dir: Path, filename: str, content: str) -> Path:
+    """Create a legacy-format backup for a file below root_dir."""
+    backup_path = backup_dir / filename
+    backup_path.parent.mkdir(parents=True)
+    backup_path.write_text(content)
+    return backup_path
+
+
+def create_root_file(root_dir: Path, filename: str, content: str) -> Path:
+    """Create a file below a media root."""
+    file_path = root_dir / filename
+    file_path.parent.mkdir(parents=True)
+    file_path.write_text(content)
+    return file_path
+
+
 def test_backup_with_none_backup_dir() -> None:
     """Test backup functions with None backup_dir."""
     with tempfile.TemporaryDirectory() as temp_dir:
@@ -291,15 +307,12 @@ def test_get_backup_path_finds_legacy_format() -> None:
         backup_dir = temp_path / "backup"
 
         # Original file
-        show_dir = root_dir / "Show A"
-        show_dir.mkdir(parents=True)
-        file_path = show_dir / "tvshow.nfo"
-        file_path.write_text("original")
+        file_path = create_root_file(root_dir, "Show A/tvshow.nfo", "original")
 
         # Legacy backup: relative to root_dir
-        legacy_backup = backup_dir / "Show A" / "tvshow.nfo"
-        legacy_backup.parent.mkdir(parents=True)
-        legacy_backup.write_text("original")
+        legacy_backup = create_legacy_backup(
+            backup_dir, "Show A/tvshow.nfo", "original"
+        )
 
         # New-format path does NOT exist, but legacy does
         new_backup = backup_dir / file_path.relative_to("/")
@@ -316,15 +329,14 @@ def test_create_backup_skips_when_legacy_backup_exists() -> None:
         root_dir = temp_path / "tv"
         backup_dir = temp_path / "backup"
 
-        show_dir = root_dir / "Show A"
-        show_dir.mkdir(parents=True)
-        file_path = show_dir / "tvshow.nfo"
-        file_path.write_text("translated content")
+        file_path = create_root_file(
+            root_dir, "Show A/tvshow.nfo", "translated content"
+        )
 
         # Create legacy backup
-        legacy_backup = backup_dir / "Show A" / "tvshow.nfo"
-        legacy_backup.parent.mkdir(parents=True)
-        legacy_backup.write_text("original content")
+        legacy_backup = create_legacy_backup(
+            backup_dir, "Show A/tvshow.nfo", "original content"
+        )
 
         result = create_backup(file_path, backup_dir, [root_dir])
         assert result is True
@@ -343,15 +355,12 @@ def test_restore_from_backup_uses_legacy_format() -> None:
         root_dir = temp_path / "tv"
         backup_dir = temp_path / "backup"
 
-        show_dir = root_dir / "Show A"
-        show_dir.mkdir(parents=True)
-        file_path = show_dir / "tvshow.nfo"
-        file_path.write_text("translated content")
+        file_path = create_root_file(
+            root_dir, "Show A/tvshow.nfo", "translated content"
+        )
 
         # Legacy backup only
-        legacy_backup = backup_dir / "Show A" / "tvshow.nfo"
-        legacy_backup.parent.mkdir(parents=True)
-        legacy_backup.write_text("original content")
+        create_legacy_backup(backup_dir, "Show A/tvshow.nfo", "original content")
 
         result = restore_from_backup(file_path, backup_dir, [root_dir])
         assert result is True
@@ -365,11 +374,9 @@ def test_legacy_fallback_stem_matching() -> None:
         root_dir = temp_path / "tv"
         backup_dir = temp_path / "backup"
 
-        show_dir = root_dir / "Show A"
-        show_dir.mkdir(parents=True)
-        # Current file is .jpg
-        file_path_jpg = show_dir / "poster.jpg"
-        file_path_jpg.write_bytes(b"JPEG translated")
+        file_path_jpg = create_root_file(
+            root_dir, "Show A/poster.jpg", "JPEG translated"
+        )
 
         # Legacy backup is .png (stem matches)
         legacy_backup_png = backup_dir / "Show A" / "poster.png"
@@ -387,15 +394,10 @@ def test_legacy_fallback_not_used_without_root_dirs() -> None:
         root_dir = temp_path / "tv"
         backup_dir = temp_path / "backup"
 
-        show_dir = root_dir / "Show A"
-        show_dir.mkdir(parents=True)
-        file_path = show_dir / "tvshow.nfo"
-        file_path.write_text("content")
+        file_path = create_root_file(root_dir, "Show A/tvshow.nfo", "content")
 
         # Only a legacy backup exists
-        legacy_backup = backup_dir / "Show A" / "tvshow.nfo"
-        legacy_backup.parent.mkdir(parents=True)
-        legacy_backup.write_text("legacy backup")
+        create_legacy_backup(backup_dir, "Show A/tvshow.nfo", "legacy backup")
 
         # No root_dirs → only new-format path is checked → not found
         assert get_backup_path(file_path, backup_dir) is None
@@ -411,15 +413,12 @@ def test_get_backup_path_legacy_ignores_root_not_containing_file() -> None:
         backup_dir = temp_path / "backup"
 
         # File lives under root_dir_b, NOT root_dir_a
-        show_dir = root_dir_b / "Show B"
-        show_dir.mkdir(parents=True)
-        file_path = show_dir / "tvshow.nfo"
-        file_path.write_text("original")
+        file_path = create_root_file(root_dir_b, "Show B/tvshow.nfo", "original")
 
         # Legacy backup only under root_dir_b
-        legacy_backup = backup_dir / "Show B" / "tvshow.nfo"
-        legacy_backup.parent.mkdir(parents=True)
-        legacy_backup.write_text("original")
+        legacy_backup = create_legacy_backup(
+            backup_dir, "Show B/tvshow.nfo", "original"
+        )
 
         # root_dir_a does not contain the file → _legacy_backup_path returns None
         # and the loop continues to root_dir_b which does match
@@ -439,15 +438,12 @@ def test_create_backup_legacy_skips_root_not_containing_file() -> None:
         backup_dir = temp_path / "backup"
 
         # File lives under root_dir_b, NOT root_dir_a
-        show_dir = root_dir_b / "Show B"
-        show_dir.mkdir(parents=True)
-        file_path = show_dir / "tvshow.nfo"
-        file_path.write_text("content")
+        file_path = create_root_file(root_dir_b, "Show B/tvshow.nfo", "content")
 
         # Legacy backup exists under root_dir_b
-        legacy_backup = backup_dir / "Show B" / "tvshow.nfo"
-        legacy_backup.parent.mkdir(parents=True)
-        legacy_backup.write_text("original")
+        legacy_backup = create_legacy_backup(
+            backup_dir, "Show B/tvshow.nfo", "original"
+        )
 
         # root_dir_a is passed first (no match) then root_dir_b (legacy found)
         result = create_backup(file_path, backup_dir, [root_dir_a, root_dir_b])
@@ -475,10 +471,9 @@ def test_create_backup_legacy_stem_match_skips_creation() -> None:
         file_path_jpg.write_bytes(b"JPEG translated")
 
         # Legacy backup exists as .png (same stem, different extension)
-        legacy_dir = backup_dir / "Show A"
-        legacy_dir.mkdir(parents=True)
-        legacy_png = legacy_dir / "poster.png"
-        legacy_png.write_bytes(b"PNG original")
+        legacy_png = create_legacy_backup(
+            backup_dir, "Show A/poster.png", "PNG original"
+        )
 
         result = create_backup(file_path_jpg, backup_dir, [root_dir])
         assert result is True

--- a/tests/unit/test_file_scanner.py
+++ b/tests/unit/test_file_scanner.py
@@ -2,6 +2,8 @@
 
 import shutil
 import time
+from collections.abc import Iterator
+from contextlib import contextmanager
 from pathlib import Path
 from unittest.mock import Mock, patch
 
@@ -15,6 +17,27 @@ from sonarr_metadata_rewrite.file_scanner import FileScanner
 def file_scanner(test_settings: Settings) -> FileScanner:
     """Create file scanner instance."""
     return FileScanner(test_settings)
+
+
+@contextmanager
+def scanner_root(file_scanner: FileScanner, name: str) -> Iterator[Path]:
+    """Use an isolated scanner root and clean it after a test."""
+    original_root = file_scanner.settings.rewrite_root_dirs[0]
+    test_dir = original_root / name
+    file_scanner.settings.rewrite_root_dirs = [test_dir]
+    try:
+        yield test_dir
+    finally:
+        if test_dir.exists():
+            shutil.rmtree(test_dir)
+        file_scanner.settings.rewrite_root_dirs = [original_root]
+
+
+def create_scan_files(test_files: list[Path]) -> None:
+    """Create scanner input files and parent directories."""
+    for test_file in test_files:
+        test_file.parent.mkdir(parents=True, exist_ok=True)
+        test_file.touch()
 
 
 def test_file_scanner_initialization(file_scanner: FileScanner) -> None:
@@ -50,11 +73,7 @@ def test_scanner_finds_nfo_files_through_start(
 ) -> None:
     """Test that scanner finds .nfo files recursively through public interface."""
     # Use a dedicated test subdirectory
-    test_dir = file_scanner.settings.rewrite_root_dirs[0] / "test_scan"
-    original_root = file_scanner.settings.rewrite_root_dirs[0]
-    file_scanner.settings.rewrite_root_dirs = [test_dir]
-
-    try:
+    with scanner_root(file_scanner, "test_scan") as test_dir:
         test_files = [
             test_dir / "tvshow.nfo",
             test_dir / "subdir" / "episode.nfo",
@@ -62,9 +81,7 @@ def test_scanner_finds_nfo_files_through_start(
         ]
 
         # Create directories and files
-        for test_file in test_files:
-            test_file.parent.mkdir(parents=True, exist_ok=True)
-            test_file.touch()
+        create_scan_files(test_files)
 
         # Start scanner with callback
         file_scanner.start(callback_tracker)
@@ -80,11 +97,6 @@ def test_scanner_finds_nfo_files_through_start(
         called_paths = {call[0][0] for call in callback_tracker.call_args_list}
         assert test_dir / "tvshow.nfo" in called_paths
         assert test_dir / "subdir" / "episode.nfo" in called_paths
-    finally:
-        # Clean up test files and restore original root
-        if test_dir.exists():
-            shutil.rmtree(test_dir)
-        file_scanner.settings.rewrite_root_dirs = [original_root]
 
 
 def test_scanner_case_insensitive_detection(
@@ -92,11 +104,7 @@ def test_scanner_case_insensitive_detection(
 ) -> None:
     """Test that scanner detects both .nfo and .NFO files through public interface."""
     # Use a dedicated test subdirectory
-    test_dir = file_scanner.settings.rewrite_root_dirs[0] / "test_case_scan"
-    original_root = file_scanner.settings.rewrite_root_dirs[0]
-    file_scanner.settings.rewrite_root_dirs = [test_dir]
-
-    try:
+    with scanner_root(file_scanner, "test_case_scan") as test_dir:
         test_files = [
             test_dir / "tvshow.nfo",  # lowercase
             test_dir / "series.NFO",  # uppercase
@@ -106,9 +114,7 @@ def test_scanner_case_insensitive_detection(
         ]
 
         # Create directories and files
-        for test_file in test_files:
-            test_file.parent.mkdir(parents=True, exist_ok=True)
-            test_file.touch()
+        create_scan_files(test_files)
 
         # Start scanner with callback
         file_scanner.start(callback_tracker)
@@ -126,11 +132,6 @@ def test_scanner_case_insensitive_detection(
         assert test_dir / "series.NFO" in called_paths
         assert test_dir / "subdir" / "episode.nfo" in called_paths
         assert test_dir / "subdir" / "special.NFO" in called_paths
-    finally:
-        # Clean up test files and restore original root
-        if test_dir.exists():
-            shutil.rmtree(test_dir)
-        file_scanner.settings.rewrite_root_dirs = [original_root]
 
 
 def test_scanner_missing_directory_handling(
@@ -165,11 +166,7 @@ def test_scanner_finds_both_nfo_and_images(
     file_scanner: FileScanner, callback_tracker: Mock
 ) -> None:
     """Test scanner finds both NFO and image files, ignoring non-supported images."""
-    test_dir = file_scanner.settings.rewrite_root_dirs[0] / "test_mixed_scan"
-    original_root = file_scanner.settings.rewrite_root_dirs[0]
-    file_scanner.settings.rewrite_root_dirs = [test_dir]
-
-    try:
+    with scanner_root(file_scanner, "test_mixed_scan") as test_dir:
         test_files = [
             test_dir / "tvshow.nfo",
             test_dir / "poster.jpg",
@@ -177,9 +174,7 @@ def test_scanner_finds_both_nfo_and_images(
             test_dir / "banner.jpg",  # Should be ignored
         ]
 
-        for test_file in test_files:
-            test_file.parent.mkdir(parents=True, exist_ok=True)
-            test_file.touch()
+        create_scan_files(test_files)
 
         file_scanner.start(callback_tracker)
         time.sleep(0.1)
@@ -192,30 +187,20 @@ def test_scanner_finds_both_nfo_and_images(
         assert test_dir / "poster.jpg" in called_paths
         assert test_dir / "clearlogo.png" in called_paths
         assert test_dir / "banner.jpg" not in called_paths
-    finally:
-        if test_dir.exists():
-            shutil.rmtree(test_dir)
-        file_scanner.settings.rewrite_root_dirs = [original_root]
 
 
 def test_scanner_processes_nfo_and_images(
     file_scanner: FileScanner, callback_tracker: Mock
 ) -> None:
     """Test scanner processes NFO and image files (order not enforced)."""
-    test_dir = file_scanner.settings.rewrite_root_dirs[0] / "test_order_scan"
-    original_root = file_scanner.settings.rewrite_root_dirs[0]
-    file_scanner.settings.rewrite_root_dirs = [test_dir]
-
-    try:
+    with scanner_root(file_scanner, "test_order_scan") as test_dir:
         test_files = [
             test_dir / "poster.jpg",
             test_dir / "tvshow.nfo",
             test_dir / "clearlogo.png",
         ]
 
-        for test_file in test_files:
-            test_file.parent.mkdir(parents=True, exist_ok=True)
-            test_file.touch()
+        create_scan_files(test_files)
 
         file_scanner.start(callback_tracker)
         time.sleep(0.1)
@@ -226,29 +211,19 @@ def test_scanner_processes_nfo_and_images(
         assert test_dir / "tvshow.nfo" in called_paths
         assert test_dir / "poster.jpg" in called_paths
         assert test_dir / "clearlogo.png" in called_paths
-    finally:
-        if test_dir.exists():
-            shutil.rmtree(test_dir)
-        file_scanner.settings.rewrite_root_dirs = [original_root]
 
 
 def test_scanner_image_only_directory(
     file_scanner: FileScanner, callback_tracker: Mock
 ) -> None:
     """Test scanner processes image-only directories successfully."""
-    test_dir = file_scanner.settings.rewrite_root_dirs[0] / "test_images_only"
-    original_root = file_scanner.settings.rewrite_root_dirs[0]
-    file_scanner.settings.rewrite_root_dirs = [test_dir]
-
-    try:
+    with scanner_root(file_scanner, "test_images_only") as test_dir:
         test_files = [
             test_dir / "poster.jpg",
             test_dir / "clearlogo.png",
         ]
 
-        for test_file in test_files:
-            test_file.parent.mkdir(parents=True, exist_ok=True)
-            test_file.touch()
+        create_scan_files(test_files)
 
         file_scanner.start(callback_tracker)
         time.sleep(0.1)
@@ -259,10 +234,6 @@ def test_scanner_image_only_directory(
         called_paths = {call[0][0] for call in callback_tracker.call_args_list}
         assert test_dir / "poster.jpg" in called_paths
         assert test_dir / "clearlogo.png" in called_paths
-    finally:
-        if test_dir.exists():
-            shutil.rmtree(test_dir)
-        file_scanner.settings.rewrite_root_dirs = [original_root]
 
 
 def test_scanner_handles_scan_loop_exception(

--- a/tests/unit/test_image_processor.py
+++ b/tests/unit/test_image_processor.py
@@ -72,6 +72,22 @@ def create_test_image(path: Path) -> None:
     path.write_bytes(output.getvalue())
 
 
+def create_marked_jpeg(path: Path) -> None:
+    """Create a JPEG marked as a Japanese TMDB image."""
+    image = Image.new("RGB", (100, 100), color="red")
+    output = BytesIO()
+    image.save(output, format="JPEG")
+    marker = ImageCandidate(file_path="/ja.jpg", iso_639_1="ja", iso_3166_1="JP")
+    embed_marker_and_atomic_write(output.getvalue(), path, marker)
+
+
+def backup_path_for(image_processor: ImageProcessor, image_path: Path) -> Path:
+    """Return backup path for an image using absolute-path layout."""
+    backup_root = image_processor.settings.original_files_backup_dir
+    assert backup_root is not None
+    return backup_root / image_path.relative_to("/")
+
+
 class TestProcessSuccessScenarios:
     """Tests for successful image processing scenarios."""
 
@@ -274,23 +290,14 @@ class TestProcessSuccessScenarios:
         poster_path = series_dir / "poster.jpg"
         nfo_path = series_dir / "tvshow.nfo"
 
-        # Create backup dir using correct absolute-path structure
-        backup_root = image_processor.settings.original_files_backup_dir
-        assert backup_root is not None
-        backup_path = backup_root / poster_path.relative_to("/")
+        backup_path = backup_path_for(image_processor, poster_path)
         backup_path.parent.mkdir(parents=True, exist_ok=True)
 
         # Create original backup (no marker)
         original_img = Image.new("RGB", (100, 100), color="white")
         original_img.save(backup_path, format="JPEG")
 
-        # Create current file with ja-JP marker
-        current_img = Image.new("RGB", (100, 100), color="red")
-        current_output = BytesIO()
-        current_img.save(current_output, format="JPEG")
-
-        marker = ImageCandidate(file_path="/ja.jpg", iso_639_1="ja", iso_3166_1="JP")
-        embed_marker_and_atomic_write(current_output.getvalue(), poster_path, marker)
+        create_marked_jpeg(poster_path)
 
         create_test_nfo(nfo_path, 12345)
 
@@ -317,10 +324,7 @@ class TestProcessSuccessScenarios:
         poster_path = series_dir / "poster.jpg"
         nfo_path = series_dir / "tvshow.nfo"
 
-        # Create backup dir using correct absolute-path structure
-        backup_root = image_processor.settings.original_files_backup_dir
-        assert backup_root is not None
-        backup_path = backup_root / poster_path.relative_to("/")
+        backup_path = backup_path_for(image_processor, poster_path)
         backup_path.parent.mkdir(parents=True, exist_ok=True)
 
         # Create current file without marker (original)
@@ -350,13 +354,7 @@ class TestProcessSuccessScenarios:
         poster_path = series_dir / "poster.jpg"
         nfo_path = series_dir / "tvshow.nfo"
 
-        # Create current file with marker but no backup
-        current_img = Image.new("RGB", (100, 100), color="red")
-        current_output = BytesIO()
-        current_img.save(current_output, format="JPEG")
-
-        marker = ImageCandidate(file_path="/ja.jpg", iso_639_1="ja", iso_3166_1="JP")
-        embed_marker_and_atomic_write(current_output.getvalue(), poster_path, marker)
+        create_marked_jpeg(poster_path)
 
         create_test_nfo(nfo_path, 12345)
 
@@ -380,11 +378,7 @@ class TestProcessSuccessScenarios:
         poster_path = series_dir / "poster.jpg"
         nfo_path = series_dir / "tvshow.nfo"
 
-        # Create backup dir using correct absolute-path structure
-        # Backup is poster.png (different extension than current poster.jpg)
-        backup_root = image_processor.settings.original_files_backup_dir
-        assert backup_root is not None
-        backup_parent = (backup_root / poster_path.relative_to("/")).parent
+        backup_parent = backup_path_for(image_processor, poster_path).parent
         backup_parent.mkdir(parents=True, exist_ok=True)
         # Backup is poster.png (different extension)
         backup_path = backup_parent / "poster.png"
@@ -393,13 +387,7 @@ class TestProcessSuccessScenarios:
         original_img = Image.new("RGB", (100, 100), color="white")
         original_img.save(backup_path, format="PNG")
 
-        # Create current JPEG with marker
-        current_img = Image.new("RGB", (100, 100), color="red")
-        current_output = BytesIO()
-        current_img.save(current_output, format="JPEG")
-
-        marker = ImageCandidate(file_path="/ja.jpg", iso_639_1="ja", iso_3166_1="JP")
-        embed_marker_and_atomic_write(current_output.getvalue(), poster_path, marker)
+        create_marked_jpeg(poster_path)
 
         create_test_nfo(nfo_path, 12345)
 

--- a/tests/unit/test_image_utils.py
+++ b/tests/unit/test_image_utils.py
@@ -24,13 +24,24 @@ def _create_image_bytes(size: tuple[int, int], color: str, fmt: str) -> bytes:
     return output.getvalue()
 
 
+def _write_jpeg_marker(
+    path: Path, marker_data: dict[str, str | None], prefix: bytes = b""
+) -> None:
+    """Write a JPEG with marker JSON in EXIF UserComment."""
+    user_comment = prefix + json.dumps(marker_data).encode("utf-8")
+    exif_dict = {"Exif": {piexif.ExifIFD.UserComment: user_comment}}
+    Image.new("RGB", (100, 100), color="blue").save(
+        path, "JPEG", exif=piexif.dump(exif_dict)
+    )
+
+
 class TestReadEmbeddedMarker:
     """Tests for read_embedded_marker() function."""
 
     def test_read_png_with_text_chunk(self, tmp_path: Path) -> None:
         """Test reading marker from PNG with tEXt chunk."""
         # Create PNG with tEXt chunk containing JSON marker
-        marker_data = {
+        marker_data: dict[str, str | None] = {
             "file_path": "/test/path.png",
             "iso_639_1": "en",
             "iso_3166_1": "US",
@@ -51,7 +62,7 @@ class TestReadEmbeddedMarker:
 
     def test_read_jpeg_with_exif(self, tmp_path: Path) -> None:
         """Test reading marker from JPEG with EXIF UserComment."""
-        marker_data = {
+        marker_data: dict[str, str | None] = {
             "file_path": "/test/path.jpg",
             "iso_639_1": "ja",
             "iso_3166_1": "JP",
@@ -59,13 +70,7 @@ class TestReadEmbeddedMarker:
         jpeg_path = tmp_path / "test.jpg"
 
         # Create JPEG with EXIF UserComment
-        img = Image.new("RGB", (100, 100), color="blue")
-
-        user_comment = json.dumps(marker_data).encode("utf-8")
-        exif_dict = {"Exif": {piexif.ExifIFD.UserComment: user_comment}}
-        exif_bytes = piexif.dump(exif_dict)
-
-        img.save(jpeg_path, "JPEG", exif=exif_bytes)
+        _write_jpeg_marker(jpeg_path, marker_data)
 
         # Read marker
         result = read_embedded_marker(jpeg_path)
@@ -122,15 +127,7 @@ class TestReadEmbeddedMarker:
         }
         jpeg_path = tmp_path / "unicode.jpg"
 
-        img = Image.new("RGB", (100, 100), color="blue")
-
-        # Create UserComment with UNICODE\x00 prefix
-        marker_json = json.dumps(marker_data)
-        user_comment = b"UNICODE\x00" + marker_json.encode("utf-8")
-        exif_dict = {"Exif": {piexif.ExifIFD.UserComment: user_comment}}
-        exif_bytes = piexif.dump(exif_dict)
-
-        img.save(jpeg_path, "JPEG", exif=exif_bytes)
+        _write_jpeg_marker(jpeg_path, marker_data, b"UNICODE\x00")
 
         result = read_embedded_marker(jpeg_path)
         assert result == ImageCandidate(
@@ -146,15 +143,7 @@ class TestReadEmbeddedMarker:
         }
         jpeg_path = tmp_path / "ascii.jpg"
 
-        img = Image.new("RGB", (100, 100), color="green")
-
-        # Create UserComment with ASCII\x00\x00\x00 prefix
-        marker_json = json.dumps(marker_data)
-        user_comment = b"ASCII\x00\x00\x00" + marker_json.encode("utf-8")
-        exif_dict = {"Exif": {piexif.ExifIFD.UserComment: user_comment}}
-        exif_bytes = piexif.dump(exif_dict)
-
-        img.save(jpeg_path, "JPEG", exif=exif_bytes)
+        _write_jpeg_marker(jpeg_path, marker_data, b"ASCII\x00\x00\x00")
 
         result = read_embedded_marker(jpeg_path)
         assert result == ImageCandidate(

--- a/tests/unit/test_metadata_processor.py
+++ b/tests/unit/test_metadata_processor.py
@@ -17,7 +17,33 @@ from sonarr_metadata_rewrite.models import (
     TranslatedString,
 )
 from sonarr_metadata_rewrite.translator import Translator
-from tests.conftest import assert_process_result, create_test_settings
+from tests.conftest import (
+    SAMPLE_MULTI_EPISODE_NFO,
+    assert_process_result,
+    create_test_settings,
+)
+
+
+def translated_content(
+    title: str, description: str, language: str
+) -> TranslatedContent:
+    """Create translated content with one language for both fields."""
+    return TranslatedContent(
+        title=TranslatedString(content=title, language=language),
+        description=TranslatedString(content=description, language=language),
+    )
+
+
+def multi_episode_processor(
+    test_data_dir: Path, create_test_files: Callable[[str, Path], Path]
+) -> tuple[MetadataProcessor, Mock, Path]:
+    """Create processor and series directory for multi-episode tests."""
+    mock_translator = Mock(spec=Translator)
+    processor = MetadataProcessor(create_test_settings(test_data_dir), mock_translator)
+    series_dir = test_data_dir / "Breaking Bad"
+    series_dir.mkdir(parents=True, exist_ok=True)
+    create_test_files("tvshow.nfo", series_dir / "tvshow.nfo")
+    return processor, mock_translator, series_dir
 
 
 @pytest.fixture
@@ -25,10 +51,7 @@ def mock_translator() -> Mock:
     """Create mock translator."""
     translator = Mock(spec=Translator)
     translator.get_translations.return_value = {
-        "zh-CN": TranslatedContent(
-            title=TranslatedString(content="示例剧集", language="zh-CN"),
-            description=TranslatedString(content="这是一个示例描述", language="zh-CN"),
-        )
+        "zh-CN": translated_content("示例剧集", "这是一个示例描述", "zh-CN")
     }
     # Mock external ID lookup to return None (no external mapping)
     translator.find_tmdb_id_by_external_id.return_value = None
@@ -154,18 +177,9 @@ def test_process_file_language_preference(
     # Create mock translator with multiple languages
     assert isinstance(processor.translator, Mock)
     processor.translator.get_translations.return_value = {
-        "en": TranslatedContent(
-            title=TranslatedString(content="English Title", language="en"),
-            description=TranslatedString(content="English Description", language="en"),
-        ),
-        "zh-CN": TranslatedContent(
-            title=TranslatedString(content="中文标题", language="zh-CN"),
-            description=TranslatedString(content="中文描述", language="zh-CN"),
-        ),
-        "ja-JP": TranslatedContent(
-            title=TranslatedString(content="日本語タイトル", language="ja-JP"),
-            description=TranslatedString(content="日本語の説明", language="ja-JP"),
-        ),
+        "en": translated_content("English Title", "English Description", "en"),
+        "zh-CN": translated_content("中文标题", "中文描述", "zh-CN"),
+        "ja-JP": translated_content("日本語タイトル", "日本語の説明", "ja-JP"),
     }
 
     test_path = create_test_files("tvshow.nfo", test_data_dir / "test_lang_pref.nfo")
@@ -481,14 +495,8 @@ def test_select_preferred_translation_single_language_complete(
     processor = MetadataProcessor(settings, mock_translator)
 
     all_translations = {
-        "zh-CN": TranslatedContent(
-            title=TranslatedString(content="中文标题", language="zh-CN"),
-            description=TranslatedString(content="中文描述", language="zh-CN"),
-        ),
-        "ja-JP": TranslatedContent(
-            title=TranslatedString(content="日本語タイトル", language="ja-JP"),
-            description=TranslatedString(content="日本語の説明", language="ja-JP"),
-        ),
+        "zh-CN": translated_content("中文标题", "中文描述", "zh-CN"),
+        "ja-JP": translated_content("日本語タイトル", "日本語の説明", "ja-JP"),
     }
 
     result = processor._select_preferred_translation(all_translations)
@@ -594,18 +602,9 @@ def test_process_file_multiple_preferred_languages_first_match(
     # Mock translator with available translations (missing Korean)
     mock_translator = Mock()
     mock_translator.get_translations.return_value = {
-        "ja-JP": TranslatedContent(
-            title=TranslatedString(content="日本語タイトル", language="ja-JP"),
-            description=TranslatedString(content="日本語の説明", language="ja-JP"),
-        ),
-        "zh-CN": TranslatedContent(
-            title=TranslatedString(content="中文标题", language="zh-CN"),
-            description=TranslatedString(content="中文描述", language="zh-CN"),
-        ),
-        "en": TranslatedContent(
-            title=TranslatedString(content="English Title", language="en"),
-            description=TranslatedString(content="English Description", language="en"),
-        ),
+        "ja-JP": translated_content("日本語タイトル", "日本語の説明", "ja-JP"),
+        "zh-CN": translated_content("中文标题", "中文描述", "zh-CN"),
+        "en": translated_content("English Title", "English Description", "en"),
     }
 
     processor = MetadataProcessor(settings, mock_translator)
@@ -685,24 +684,10 @@ def test_process_file_multiple_preferred_languages_partial_matches(
     # Mock translator with some matching languages (missing Arabic and Thai)
     mock_translator = Mock()
     mock_translator.get_translations.return_value = {
-        "zh-CN": TranslatedContent(
-            title=TranslatedString(content="中文标题", language="zh-CN"),
-            description=TranslatedString(content="中文描述", language="zh-CN"),
-        ),
-        "ja-JP": TranslatedContent(
-            title=TranslatedString(content="日本語タイトル", language="ja-JP"),
-            description=TranslatedString(content="日本語の説明", language="ja-JP"),
-        ),
-        "en": TranslatedContent(
-            title=TranslatedString(content="English Title", language="en"),
-            description=TranslatedString(content="English Description", language="en"),
-        ),
-        "de": TranslatedContent(
-            title=TranslatedString(content="Deutscher Titel", language="de"),
-            description=TranslatedString(
-                content="Deutsche Beschreibung", language="de"
-            ),
-        ),
+        "zh-CN": translated_content("中文标题", "中文描述", "zh-CN"),
+        "ja-JP": translated_content("日本語タイトル", "日本語の説明", "ja-JP"),
+        "en": translated_content("English Title", "English Description", "en"),
+        "de": translated_content("Deutscher Titel", "Deutsche Beschreibung", "de"),
     }
 
     processor = MetadataProcessor(settings, mock_translator)
@@ -735,22 +720,9 @@ def test_process_file_single_preferred_language_available(
 
     mock_translator = Mock()
     mock_translator.get_translations.return_value = {
-        "fr": TranslatedContent(
-            title=TranslatedString(content="Titre français", language="fr"),
-            description=TranslatedString(
-                content="Description française", language="fr"
-            ),
-        ),
-        "en": TranslatedContent(
-            title=TranslatedString(content="English Title", language="en"),
-            description=TranslatedString(content="English Description", language="en"),
-        ),
-        "de": TranslatedContent(
-            title=TranslatedString(content="Deutscher Titel", language="de"),
-            description=TranslatedString(
-                content="Deutsche Beschreibung", language="de"
-            ),
-        ),
+        "fr": translated_content("Titre français", "Description française", "fr"),
+        "en": translated_content("English Title", "English Description", "en"),
+        "de": translated_content("Deutscher Titel", "Deutsche Beschreibung", "de"),
     }
 
     processor = MetadataProcessor(settings, mock_translator)
@@ -780,20 +752,9 @@ def test_process_file_single_preferred_language_not_available(
 
     mock_translator = Mock()
     mock_translator.get_translations.return_value = {
-        "fr": TranslatedContent(
-            title=TranslatedString(content="Titre français", language="fr"),
-            description=TranslatedString(
-                content="Description française", language="fr"
-            ),
-        ),
-        "en": TranslatedContent(
-            title=TranslatedString(content="English Title", language="en"),
-            description=TranslatedString(content="English Description", language="en"),
-        ),
-        "zh-CN": TranslatedContent(
-            title=TranslatedString(content="中文标题", language="zh-CN"),
-            description=TranslatedString(content="中文描述", language="zh-CN"),
-        ),
+        "fr": translated_content("Titre français", "Description française", "fr"),
+        "en": translated_content("English Title", "English Description", "en"),
+        "zh-CN": translated_content("中文标题", "中文描述", "zh-CN"),
     }
 
     processor = MetadataProcessor(settings, mock_translator)
@@ -1273,10 +1234,7 @@ def test_process_file_episode_inherits_parent_tvdb_id(
 
     mock_translator = Mock(spec=Translator)
     mock_translator.get_translations.return_value = {
-        "zh-CN": TranslatedContent(
-            title=TranslatedString(content="示例剧集", language="zh-CN"),
-            description=TranslatedString(content="这是一个示例描述", language="zh-CN"),
-        )
+        "zh-CN": translated_content("示例剧集", "这是一个示例描述", "zh-CN")
     }
     # Mock external ID lookup to return TMDB ID for TVDB lookup
     mock_translator.find_tmdb_id_by_external_id.return_value = 1396
@@ -1358,10 +1316,7 @@ def test_process_file_mixed_id_scenarios(
 
     mock_translator = Mock(spec=Translator)
     mock_translator.get_translations.return_value = {
-        "zh-CN": TranslatedContent(
-            title=TranslatedString(content="示例剧集", language="zh-CN"),
-            description=TranslatedString(content="这是一个示例描述", language="zh-CN"),
-        )
+        "zh-CN": translated_content("示例剧集", "这是一个示例描述", "zh-CN")
     }
     # Mock external ID lookup to return different TMDB ID
     mock_translator.find_tmdb_id_by_external_id.return_value = 2468
@@ -1406,10 +1361,7 @@ def test_process_file_episode_external_id_priority_over_parent_external_id(
 
     mock_translator = Mock(spec=Translator)
     mock_translator.get_translations.return_value = {
-        "zh-CN": TranslatedContent(
-            title=TranslatedString(content="示例剧集", language="zh-CN"),
-            description=TranslatedString(content="这是一个示例描述", language="zh-CN"),
-        )
+        "zh-CN": translated_content("示例剧集", "这是一个示例描述", "zh-CN")
     }
     # Mock external ID lookup to return TMDB ID for episode's external ID
     mock_translator.find_tmdb_id_by_external_id.return_value = 2468
@@ -1498,24 +1450,15 @@ def test_process_file_multi_episode_partial_update(
     create_test_files: Callable[[str, Path], Path],
 ) -> None:
     """Test partial translation updates for multi-episode NFO files."""
-    settings = create_test_settings(test_data_dir)
-    mock_translator = Mock(spec=Translator)
-    processor = MetadataProcessor(settings, mock_translator)
-
-    series_dir = test_data_dir / "Breaking Bad"
-    series_dir.mkdir(parents=True, exist_ok=True)
-    create_test_files("tvshow.nfo", series_dir / "tvshow.nfo")
+    processor, mock_translator, series_dir = multi_episode_processor(
+        test_data_dir, create_test_files
+    )
     nfo_path = create_test_files("multi_episode.nfo", series_dir / "episodes.nfo")
 
     def get_translations(tmdb_ids: TmdbIds) -> dict[str, TranslatedContent]:
         if tmdb_ids.episode == 1:
             return {
-                "zh-CN": TranslatedContent(
-                    title=TranslatedString(content="试播集", language="zh-CN"),
-                    description=TranslatedString(
-                        content="沃尔特开始了犯罪生涯。", language="zh-CN"
-                    ),
-                )
+                "zh-CN": translated_content("试播集", "沃尔特开始了犯罪生涯。", "zh-CN")
             }
         return {}
 
@@ -1660,28 +1603,15 @@ def test_process_file_multi_episode_skips_entry_without_episode_numbers(
     )
     nfo_path = series_dir / "episodes.nfo"
     nfo_path.write_text(
-        """<?xml version="1.0" encoding="utf-8"?>
-<episodedetails>
-  <title>Pilot</title>
-  <plot>Walter White begins a new life in crime.</plot>
-  <season>1</season>
-  <episode>1</episode>
-</episodedetails>
-<episodedetails>
-  <title>Broken Entry</title>
-  <plot>Missing episode number.</plot>
-</episodedetails>
-""",
+        SAMPLE_MULTI_EPISODE_NFO.replace(
+            "<season>1</season>\n  <episode>2</episode>",
+            "<season>1</season>",
+        ),
         encoding="utf-8",
     )
 
     mock_translator.get_translations.return_value = {
-        "zh-CN": TranslatedContent(
-            title=TranslatedString(content="试播集", language="zh-CN"),
-            description=TranslatedString(
-                content="沃尔特开始了犯罪生涯。", language="zh-CN"
-            ),
-        )
+        "zh-CN": translated_content("试播集", "沃尔特开始了犯罪生涯。", "zh-CN")
     }
     mock_translator.find_tmdb_id_by_external_id.return_value = None
 
@@ -1703,50 +1633,23 @@ def test_process_file_multi_episode_reports_already_matched_entries(
     create_test_files: Callable[[str, Path], Path],
 ) -> None:
     """Test multi-episode message includes already matched entries."""
-    settings = create_test_settings(test_data_dir)
-    mock_translator = Mock(spec=Translator)
-    processor = MetadataProcessor(settings, mock_translator)
-
-    series_dir = test_data_dir / "Breaking Bad"
-    series_dir.mkdir(parents=True, exist_ok=True)
-    create_test_files("tvshow.nfo", series_dir / "tvshow.nfo")
+    processor, mock_translator, series_dir = multi_episode_processor(
+        test_data_dir, create_test_files
+    )
     nfo_path = series_dir / "episodes.nfo"
     nfo_path.write_text(
-        """<?xml version="1.0" encoding="utf-8"?>
-<episodedetails>
-  <title>试播集</title>
-  <plot>沃尔特开始了犯罪生涯。</plot>
-  <season>1</season>
-  <episode>1</episode>
-</episodedetails>
-<episodedetails>
-  <title>Cat's in the Bag...</title>
-  <plot>Walt and Jesse deal with the aftermath.</plot>
-  <season>1</season>
-  <episode>2</episode>
-</episodedetails>
-""",
+        SAMPLE_MULTI_EPISODE_NFO.replace("Pilot", "试播集").replace(
+            "Walter White begins a new life in crime.", "沃尔特开始了犯罪生涯。"
+        ),
         encoding="utf-8",
     )
 
     def get_translations(tmdb_ids: TmdbIds) -> dict[str, TranslatedContent]:
         if tmdb_ids.episode == 1:
             return {
-                "zh-CN": TranslatedContent(
-                    title=TranslatedString(content="试播集", language="zh-CN"),
-                    description=TranslatedString(
-                        content="沃尔特开始了犯罪生涯。", language="zh-CN"
-                    ),
-                )
+                "zh-CN": translated_content("试播集", "沃尔特开始了犯罪生涯。", "zh-CN")
             }
-        return {
-            "zh-CN": TranslatedContent(
-                title=TranslatedString(content="袋中猫", language="zh-CN"),
-                description=TranslatedString(
-                    content="两人处理善后。", language="zh-CN"
-                ),
-            )
-        }
+        return {"zh-CN": translated_content("袋中猫", "两人处理善后。", "zh-CN")}
 
     mock_translator.get_translations.side_effect = get_translations
     mock_translator.find_tmdb_id_by_external_id.return_value = None

--- a/tests/unit/test_rewrite_service.py
+++ b/tests/unit/test_rewrite_service.py
@@ -16,6 +16,17 @@ from sonarr_metadata_rewrite.models import (
 from sonarr_metadata_rewrite.rewrite_service import RewriteService
 
 
+def assert_cache_initialization_error(settings: Settings, cache_dir: Path) -> None:
+    """Assert inaccessible cache storage produces the documented error."""
+    with pytest.raises(RuntimeError) as exc_info:
+        RewriteService(settings)
+
+    error_message = str(exc_info.value)
+    assert "Failed to initialize cache" in error_message
+    assert str(cache_dir) in error_message
+    assert "not be accessible or writable" in error_message
+
+
 @pytest.fixture
 def rewrite_service(test_settings: Settings) -> RewriteService:
     """Create rewrite service instance."""
@@ -199,15 +210,7 @@ def test_cache_initialization_error(test_data_dir: Path) -> None:
             cache_dir=cache_dir,
         )
 
-        # Verify that RuntimeError is raised with clear message
-        with pytest.raises(RuntimeError) as exc_info:
-            RewriteService(settings)
-
-        # Verify error message includes the cache directory path
-        error_message = str(exc_info.value)
-        assert "Failed to initialize cache" in error_message
-        assert str(cache_dir) in error_message
-        assert "not be accessible or writable" in error_message
+        assert_cache_initialization_error(settings, cache_dir)
     finally:
         # Restore permissions for cleanup
         os.chmod(db_file, 0o644)
@@ -235,15 +238,7 @@ def test_cache_initialization_permission_error(test_data_dir: Path) -> None:
             cache_dir=cache_dir,
         )
 
-        # Verify that RuntimeError is raised with clear message
-        with pytest.raises(RuntimeError) as exc_info:
-            RewriteService(settings)
-
-        # Verify error message includes the cache directory path
-        error_message = str(exc_info.value)
-        assert "Failed to initialize cache" in error_message
-        assert str(cache_dir) in error_message
-        assert "not be accessible or writable" in error_message
+        assert_cache_initialization_error(settings, cache_dir)
     finally:
         # Restore permissions for cleanup
         os.chmod(readonly_parent, 0o755)

--- a/tests/unit/test_rollback_service.py
+++ b/tests/unit/test_rollback_service.py
@@ -8,7 +8,7 @@ import pytest
 
 from sonarr_metadata_rewrite.backup_utils import create_backup
 from sonarr_metadata_rewrite.rollback_service import RollbackService
-from tests.conftest import create_test_settings
+from tests.conftest import SAMPLE_MULTI_EPISODE_NFO, create_test_settings
 
 
 def _make_backup(original_file: Path, backup_dir: Path) -> None:
@@ -18,6 +18,18 @@ def _make_backup(original_file: Path, backup_dir: Path) -> None:
     automatically.
     """
     create_backup(original_file, backup_dir)
+
+
+def _rollback_service(test_data_dir: Path, backup_dir: Path) -> RollbackService:
+    """Create rollback service for media below test data directory."""
+    return RollbackService(
+        create_test_settings(
+            test_data_dir,
+            service_mode="rollback",
+            rewrite_root_dirs=[test_data_dir / "media"],
+            original_files_backup_dir=backup_dir,
+        )
+    )
 
 
 def test_rollback_service_init(test_data_dir: Path) -> None:
@@ -102,13 +114,7 @@ def test_execute_rollback_successful(
     # Simulate translation (overwrite original)
     original_file.write_text("Translated content")
 
-    settings = create_test_settings(
-        test_data_dir,
-        service_mode="rollback",
-        rewrite_root_dirs=[original_dir],
-        original_files_backup_dir=backup_dir,
-    )
-    service = RollbackService(settings)
+    service = _rollback_service(test_data_dir, backup_dir)
 
     with caplog.at_level(logging.INFO):
         service.execute_rollback()
@@ -141,13 +147,7 @@ def test_execute_rollback_missing_original_directory(
     original_file.unlink()
     deleted_show_dir.rmdir()
 
-    settings = create_test_settings(
-        test_data_dir,
-        service_mode="rollback",
-        rewrite_root_dirs=[original_dir],
-        original_files_backup_dir=backup_dir,
-    )
-    service = RollbackService(settings)
+    service = _rollback_service(test_data_dir, backup_dir)
 
     with caplog.at_level(logging.INFO):
         service.execute_rollback()
@@ -175,13 +175,7 @@ def test_restore_single_file_success(test_data_dir: Path) -> None:
     # Derive the backup file path the same way create_backup would
     backup_file = backup_dir / original_file.relative_to("/")
 
-    settings = create_test_settings(
-        test_data_dir,
-        service_mode="rollback",
-        rewrite_root_dirs=[original_dir],
-        original_files_backup_dir=backup_dir,
-    )
-    service = RollbackService(settings)
+    service = _rollback_service(test_data_dir, backup_dir)
 
     result = service._restore_single_file(backup_file)
 
@@ -207,13 +201,7 @@ def test_restore_single_file_missing_directory(test_data_dir: Path) -> None:
     original_file.unlink()
     deleted_show_dir.rmdir()
 
-    settings = create_test_settings(
-        test_data_dir,
-        service_mode="rollback",
-        rewrite_root_dirs=[original_dir],
-        original_files_backup_dir=backup_dir,
-    )
-    service = RollbackService(settings)
+    service = _rollback_service(test_data_dir, backup_dir)
 
     result = service._restore_single_file(backup_file)
 
@@ -518,20 +506,7 @@ def test_execute_rollback_restores_multi_episode_nfo(test_data_dir: Path) -> Non
     episode_dir = original_dir / "Breaking Bad" / "Season 01"
     episode_dir.mkdir(parents=True, exist_ok=True)
     original_file = episode_dir / "episodes.nfo"
-    original_content = """<?xml version="1.0" encoding="utf-8"?>
-<episodedetails>
-  <title>Pilot</title>
-  <plot>Walter White begins a new life in crime.</plot>
-  <season>1</season>
-  <episode>1</episode>
-</episodedetails>
-<episodedetails>
-  <title>Cat's in the Bag...</title>
-  <plot>Walt and Jesse deal with the aftermath.</plot>
-  <season>1</season>
-  <episode>2</episode>
-</episodedetails>
-"""
+    original_content = SAMPLE_MULTI_EPISODE_NFO
     original_file.write_text(original_content, encoding="utf-8")
     _make_backup(original_file, backup_dir)
 

--- a/tests/unit/test_translator.py
+++ b/tests/unit/test_translator.py
@@ -14,6 +14,18 @@ from sonarr_metadata_rewrite.models import TmdbIds, TranslatedContent, Translate
 from sonarr_metadata_rewrite.translator import Translator
 
 
+def mock_not_found_error() -> httpx.HTTPStatusError:
+    """Create a TMDB 404 error response."""
+    response = Mock(status_code=404)
+    return httpx.HTTPStatusError("Not Found", request=Mock(), response=response)
+
+
+def configure_image_response(mock_get: Mock, response: dict[str, Any]) -> None:
+    """Configure a successful image API response."""
+    mock_get.return_value.json.return_value = response
+    mock_get.return_value.raise_for_status = Mock()
+
+
 @pytest.fixture
 def translator(test_settings: Settings) -> Translator:
     """Create translator instance."""
@@ -951,12 +963,7 @@ def test_get_translations_cache_backward_compatibility_integration(
 def test_get_with_cache_404_caching(mock_get: Mock, translator: Translator) -> None:
     """Test that _get_with_cache properly caches 404 responses."""
     # Mock 404 HTTP error
-    not_found_response = Mock()
-    not_found_response.status_code = 404
-    not_found_error = httpx.HTTPStatusError(
-        "Not Found", request=Mock(), response=not_found_response
-    )
-    mock_get.side_effect = not_found_error
+    mock_get.side_effect = mock_not_found_error()
 
     # Define a simple fetch function that calls _fetch_with_retry
     def fetch_func() -> dict[str, Any]:
@@ -987,12 +994,7 @@ def test_get_with_cache_404_caching(mock_get: Mock, translator: Translator) -> N
 def test_get_translations_404_cached(mock_get: Mock, translator: Translator) -> None:
     """Test that get_translations properly caches 404 responses as empty dict."""
     # Mock 404 HTTP error
-    not_found_response = Mock()
-    not_found_response.status_code = 404
-    not_found_error = httpx.HTTPStatusError(
-        "Not Found", request=Mock(), response=not_found_response
-    )
-    mock_get.side_effect = not_found_error
+    mock_get.side_effect = mock_not_found_error()
 
     tmdb_ids = TmdbIds(tmdb_id=99999, media_type="tv")  # Non-existent series
     cache_key = f"translations:{tmdb_ids}"
@@ -1152,8 +1154,7 @@ class TestSelectBestImage:
         mock_images_response_posters: dict[str, Any],
     ) -> None:
         """Test selecting poster with exact language-country match."""
-        mock_get.return_value.json.return_value = mock_images_response_posters
-        mock_get.return_value.raise_for_status = Mock()
+        configure_image_response(mock_get, mock_images_response_posters)
 
         tmdb_ids = TmdbIds(tmdb_id=12345, media_type="tv", season=None, episode=None)
         result = translator.select_best_image(tmdb_ids, ["en-US"], kind="poster")
@@ -1171,8 +1172,7 @@ class TestSelectBestImage:
         mock_images_response_logos: dict[str, Any],
     ) -> None:
         """Test selecting clearlogo with exact language-country match."""
-        mock_get.return_value.json.return_value = mock_images_response_logos
-        mock_get.return_value.raise_for_status = Mock()
+        configure_image_response(mock_get, mock_images_response_logos)
 
         tmdb_ids = TmdbIds(tmdb_id=67890, media_type="tv", season=None, episode=None)
         result = translator.select_best_image(tmdb_ids, ["ja-JP"], kind="clearlogo")
@@ -1190,8 +1190,7 @@ class TestSelectBestImage:
         mock_images_response_posters: dict[str, Any],
     ) -> None:
         """Test movie artwork uses movie images endpoint."""
-        mock_get.return_value.json.return_value = mock_images_response_posters
-        mock_get.return_value.raise_for_status = Mock()
+        configure_image_response(mock_get, mock_images_response_posters)
 
         result = translator.select_best_image(
             TmdbIds(tmdb_id=550, media_type="movie"), ["en-US"], kind="poster"
@@ -1220,8 +1219,7 @@ class TestSelectBestImage:
             ],
             "logos": [],
         }
-        mock_get.return_value.json.return_value = season_response
-        mock_get.return_value.raise_for_status = Mock()
+        configure_image_response(mock_get, season_response)
 
         tmdb_ids = TmdbIds(tmdb_id=12345, media_type="tv", season=1)
         result = translator.select_best_image(tmdb_ids, ["en-US"], kind="poster")
@@ -1242,8 +1240,7 @@ class TestSelectBestImage:
         mock_images_response_posters: dict[str, Any],
     ) -> None:
         """Test that first preferred language match is returned."""
-        mock_get.return_value.json.return_value = mock_images_response_posters
-        mock_get.return_value.raise_for_status = Mock()
+        configure_image_response(mock_get, mock_images_response_posters)
 
         tmdb_ids = TmdbIds(tmdb_id=12345, media_type="tv", season=None, episode=None)
         # Prefer en-US first, then ja-JP
@@ -1265,8 +1262,7 @@ class TestSelectBestImage:
         mock_images_response_posters: dict[str, Any],
     ) -> None:
         """Test that no match returns None."""
-        mock_get.return_value.json.return_value = mock_images_response_posters
-        mock_get.return_value.raise_for_status = Mock()
+        configure_image_response(mock_get, mock_images_response_posters)
 
         tmdb_ids = TmdbIds(tmdb_id=12345, media_type="tv", season=None, episode=None)
         # Request fr-FR which doesn't exist in response
@@ -1299,8 +1295,7 @@ class TestSelectBestImage:
             ],
             "logos": [],
         }
-        mock_get.return_value.json.return_value = response_with_nulls
-        mock_get.return_value.raise_for_status = Mock()
+        configure_image_response(mock_get, response_with_nulls)
 
         tmdb_ids = TmdbIds(tmdb_id=12345, media_type="tv", season=None, episode=None)
         result = translator.select_best_image(tmdb_ids, ["en-US"], kind="poster")
@@ -1317,8 +1312,7 @@ class TestSelectBestImage:
         mock_images_response_posters: dict[str, Any],
     ) -> None:
         """Test that malformed language codes without hyphen are skipped."""
-        mock_get.return_value.json.return_value = mock_images_response_posters
-        mock_get.return_value.raise_for_status = Mock()
+        configure_image_response(mock_get, mock_images_response_posters)
 
         tmdb_ids = TmdbIds(tmdb_id=12345, media_type="tv", season=None, episode=None)
         # Malformed codes without hyphen should be skipped
@@ -1338,12 +1332,7 @@ class TestSelectBestImage:
         translator: Translator,
     ) -> None:
         """Test that 404 response returns None."""
-        not_found_response = Mock()
-        not_found_response.status_code = 404
-        not_found_error = httpx.HTTPStatusError(
-            "Not Found", request=Mock(), response=not_found_response
-        )
-        mock_get.side_effect = not_found_error
+        mock_get.side_effect = mock_not_found_error()
 
         tmdb_ids = TmdbIds(tmdb_id=99999, media_type="tv", season=None, episode=None)
         result = translator.select_best_image(tmdb_ids, ["en-US"], kind="poster")
@@ -1358,8 +1347,7 @@ class TestSelectBestImage:
         mock_images_response_posters: dict[str, Any],
     ) -> None:
         """Test that image selection results are cached."""
-        mock_get.return_value.json.return_value = mock_images_response_posters
-        mock_get.return_value.raise_for_status = Mock()
+        configure_image_response(mock_get, mock_images_response_posters)
 
         tmdb_ids = TmdbIds(tmdb_id=12345, media_type="tv", season=None, episode=None)
 
@@ -1381,8 +1369,7 @@ class TestSelectBestImage:
     ) -> None:
         """Test that empty posters/logos array returns None."""
         empty_response = {"id": 12345, "posters": [], "logos": []}
-        mock_get.return_value.json.return_value = empty_response
-        mock_get.return_value.raise_for_status = Mock()
+        configure_image_response(mock_get, empty_response)
 
         tmdb_ids = TmdbIds(tmdb_id=12345, media_type="tv", season=None, episode=None)
         result = translator.select_best_image(tmdb_ids, ["en-US"], kind="poster")
@@ -1403,8 +1390,7 @@ class TestSelectBestImage:
                 {"file_path": "/path1.jpg", "iso_639_1": "en", "iso_3166_1": "GB"}
             ],
         }
-        mock_get.return_value.json.return_value = response_en_gb
-        mock_get.return_value.raise_for_status = Mock()
+        configure_image_response(mock_get, response_en_gb)
 
         tmdb_ids = TmdbIds(tmdb_id=12345, media_type="tv", season=None, episode=None)
         result = translator.select_best_image(tmdb_ids, ["en-GB"], kind="poster")
@@ -1462,8 +1448,7 @@ class TestSelectBestImage:
         mock_images_response_posters: dict[str, Any],
     ) -> None:
         """Test that invalid kind returns None."""
-        mock_get.return_value.json.return_value = mock_images_response_posters
-        mock_get.return_value.raise_for_status = Mock()
+        configure_image_response(mock_get, mock_images_response_posters)
 
         tmdb_ids = TmdbIds(tmdb_id=12345, media_type="tv", season=None, episode=None)
         # "banner" is not a valid kind


### PR DESCRIPTION
## Summary
- enforce a zero-duplication `jscpd` check in pre-commit
- refactor duplicated metadata handling and unit-test setup while preserving behavior
- isolate Sonarr and Radarr integration media roots to prevent shared container state
- consolidate Arr container setup, readiness checks, and deletion polling
- document shared environment files for Docker, Compose, and rollback usage

## Validation
- `./scripts/run-unit-tests.sh`
- `./scripts/run-integration-tests.sh` (12 passed)
- `./scripts/lint.sh --check`
- `npx --no-install jscpd --reporters ai --no-tips`