### PR TITLE
[test] fix unclosed SQLite connection warnings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,6 +98,10 @@ warn_required_dynamic_aliases = true
 minversion = "7.0"
 addopts = "-ra -q --strict-markers --cov=src/sonarr_metadata_rewrite --cov-report=term-missing"
 testpaths = ["tests"]
+filterwarnings = [
+    "error::ResourceWarning",
+    "error::pytest.PytestUnraisableExceptionWarning",
+]
 markers = [
     "slow: marks tests as slow (integration tests)",
     "unit: marks tests as unit tests",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 """Shared test configuration and fixtures."""
 
+import gc
 import tempfile
 from collections.abc import Callable, Generator
 from pathlib import Path
@@ -10,6 +11,14 @@ import pytest
 
 from sonarr_metadata_rewrite.config import Settings
 from sonarr_metadata_rewrite.models import MetadataProcessResult
+
+
+@pytest.fixture(autouse=True)
+def collect_garbage() -> Generator[None, None, None]:
+    """Collect unclosed resources before pytest finishes each test."""
+    yield
+    gc.collect()
+
 
 # Inline test data constants
 SAMPLE_TVSHOW_NFO = """<?xml version="1.0" encoding="utf-8"?>

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -120,7 +120,10 @@ def patch_fetch_with_retry() -> Generator[None, None, None]:
 
 
 @pytest.fixture
-def translator(test_settings: Settings, tmp_path: Path) -> Translator:
+def translator(
+    test_settings: Settings, tmp_path: Path
+) -> Generator[Translator, None, None]:
     """Create a Translator instance with a temporary cache for testing."""
     cache = Cache(tmp_path / "cache")
-    return Translator(test_settings, cache)
+    yield Translator(test_settings, cache)
+    cache.close()

--- a/tests/unit/test_rewrite_service.py
+++ b/tests/unit/test_rewrite_service.py
@@ -1,5 +1,6 @@
 """Unit tests for rewrite service."""
 
+import sqlite3
 from collections.abc import Callable, Generator
 from pathlib import Path
 from unittest.mock import Mock, patch
@@ -28,9 +29,11 @@ def assert_cache_initialization_error(settings: Settings, cache_dir: Path) -> No
 
 
 @pytest.fixture
-def rewrite_service(test_settings: Settings) -> RewriteService:
+def rewrite_service(test_settings: Settings) -> Generator[RewriteService, None, None]:
     """Create rewrite service instance."""
-    return RewriteService(test_settings)
+    service = RewriteService(test_settings)
+    yield service
+    service.stop()
 
 
 def test_rewrite_service_initialization(rewrite_service: RewriteService) -> None:
@@ -183,37 +186,19 @@ def test_service_integration_processing_error_with_exception(
 
 def test_cache_initialization_error(test_data_dir: Path) -> None:
     """Test cache initialization errors are handled with clear messages."""
-    import os
-
-    from diskcache import Cache  # type: ignore[import-untyped]
-
-    from sonarr_metadata_rewrite.config import Settings
-
-    # Create a cache directory and initialize it
     cache_dir = test_data_dir / "readonly_cache"
-    cache_dir.mkdir(parents=True, exist_ok=True)
+    settings = Settings(
+        tmdb_api_key="test_key",
+        rewrite_root_dirs=[test_data_dir],
+        preferred_languages=["en-US"],
+        cache_dir=cache_dir,
+    )
 
-    # Create a cache to generate the database file
-    cache = Cache(str(cache_dir))
-    cache.close()
-
-    # Make the cache database file read-only to trigger sqlite3.OperationalError
-    db_file = cache_dir / "cache.db"
-    os.chmod(db_file, 0o444)
-
-    try:
-        # Create settings pointing to the read-only cache
-        settings = Settings(
-            tmdb_api_key="test_key",
-            rewrite_root_dirs=[test_data_dir],
-            preferred_languages=["en-US"],
-            cache_dir=cache_dir,
-        )
-
+    with patch(
+        "sonarr_metadata_rewrite.rewrite_service.Cache",
+        side_effect=sqlite3.OperationalError("attempt to write a readonly database"),
+    ):
         assert_cache_initialization_error(settings, cache_dir)
-    finally:
-        # Restore permissions for cleanup
-        os.chmod(db_file, 0o644)
 
 
 def test_cache_initialization_permission_error(test_data_dir: Path) -> None:

--- a/tests/unit/test_translator.py
+++ b/tests/unit/test_translator.py
@@ -1,6 +1,7 @@
 """Unit tests for translator."""
 
 import json
+from collections.abc import Generator
 from types import SimpleNamespace
 from typing import Any
 from unittest.mock import Mock, patch
@@ -27,13 +28,15 @@ def configure_image_response(mock_get: Mock, response: dict[str, Any]) -> None:
 
 
 @pytest.fixture
-def translator(test_settings: Settings) -> Translator:
+def translator(test_settings: Settings) -> Generator[Translator, None, None]:
     """Create translator instance."""
     cache = Cache(str(test_settings.cache_dir))
     translator = Translator(test_settings, cache)
     # Clear the cache to ensure clean tests
     translator.cache.clear()
-    return translator
+    yield translator
+    translator.close()
+    cache.close()
 
 
 @pytest.fixture
@@ -385,6 +388,7 @@ def test_close_method(test_settings: Settings) -> None:
     assert translator.client is not None
     assert isinstance(translator.cache, Cache)
     translator.close()
+    cache.close()
     # Client should be closed after calling close()
 
 

--- a/vulture_whitelist.py
+++ b/vulture_whitelist.py
@@ -40,6 +40,7 @@ _.return_value
 _.side_effect
 
 # Pytest fixtures with autouse=True are automatically used
+collect_garbage
 patch_time_sleep
 patch_retry_timeout
 patch_fetch_with_retry


### PR DESCRIPTION
## Summary
- Close diskcache instances created by unit-test fixtures and direct tests.
- Mock cache initialization failures without leaking diskcache connections.
- Fail pytest when resource-leak warnings occur during test teardown.

## Verification
- `./scripts/lint.sh --check`
- `./scripts/run-unit-tests.sh`
- `npx jscpd`