### PR TITLE
[feat] add tagline translation support for NFO files

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ The tool runs as a background service that:
 - Watches your media folders for when Sonarr or Radarr creates or updates `.nfo`
   files
 - Grabs the TMDB ID from those files and fetches translations from TMDB's API
-- Applies preferred languages in order, falling back when a title, plot, or
-  image is unavailable in a higher-priority language
+- Applies preferred languages in order, falling back when a title, plot,
+  tagline, or image is unavailable in a higher-priority language
 - Rewrites poster and clearlogo images based on your preferred language-country
   codes (e.g., `en-US`, `ja-JP`) when such variants exist on TMDB
 - Does this fast enough that you barely notice it happening
@@ -39,7 +39,7 @@ The tool runs as a background service that:
 
 You can configure multiple languages with fallback priority, such as Chinese
 first and Japanese second. Metadata fields may use different fallback languages
-when TMDB has only a title or plot in the higher-priority language.
+when TMDB has only a title, plot, or tagline in the higher-priority language.
 
 ## Installation
 

--- a/docs/design/radarr-movie-support.md
+++ b/docs/design/radarr-movie-support.md
@@ -65,12 +65,13 @@ the processing branch:
 
 | Root | Behavior |
 | --- | --- |
-| `<tvshow>` | Existing series title and plot rewrite. |
-| `<episodedetails>` | Episode rewrite; supports multi-episode NFO. |
-| `<movie>` | New movie title and plot rewrite. |
+| `<tvshow>` | Existing series title, plot, and tagline rewrite. |
+| `<episodedetails>` | Episode title, plot, tagline; multi-episode support. |
+| `<movie>` | New movie title, plot, and tagline rewrite. |
 | Other | Unsupported NFO result. |
 
-Movie rewriting updates only `<title>` and `<plot>`. It must preserve
+Movie rewriting updates `<title>`, `<plot>`, and a non-empty translated
+`<tagline>`. It must preserve
 `<originaltitle>`, `<sorttitle>`, all identifiers, ratings, watched state, and
 all other Radarr-generated XML.
 
@@ -98,8 +99,8 @@ TV requests remain unchanged. Movie requests use TMDB movie resources:
 | Images | `/tv/{id}/images` | `/movie/{id}/images` |
 
 Translation parsing uses `data.name` for TV and `data.title` for movies. Both
-use `data.overview` for plots. Original-title fallback uses `original_name` for
-TV and `original_title` for movies.
+use `data.overview` for plots and `data.tagline` for taglines. Original-title
+fallback uses `original_name` for TV and `original_title` for movies.
 
 The existing TV external-ID lookup remains TV-only. Movie processing does not
 call it because a Radarr movie without a TMDB ID is skipped.

--- a/src/sonarr_metadata_rewrite/file_utils.py
+++ b/src/sonarr_metadata_rewrite/file_utils.py
@@ -222,6 +222,7 @@ def _extract_episode_metadata(root: ET.Element) -> MetadataInfo:
         episode=first_entry.episode,
         title=first_entry.title,
         description=first_entry.description,
+        tagline=first_entry.tagline,
         xml_tree=first_entry.xml_tree,
         episode_entries=episode_entries,
     )
@@ -281,3 +282,7 @@ def _populate_common_metadata(
     plot_element = root.find("plot")
     if plot_element is not None and plot_element.text:
         info.description = plot_element.text.strip()
+
+    tagline_element = root.find("tagline")
+    if tagline_element is not None and tagline_element.text:
+        info.tagline = tagline_element.text.strip()

--- a/src/sonarr_metadata_rewrite/metadata_processor.py
+++ b/src/sonarr_metadata_rewrite/metadata_processor.py
@@ -84,6 +84,7 @@ class MetadataProcessor:
                 if (
                     metadata_info.title != original_metadata.title
                     or metadata_info.description != original_metadata.description
+                    or metadata_info.tagline != original_metadata.tagline
                 ):
                     selected_translation = TranslatedContent(
                         title=TranslatedString(
@@ -91,6 +92,10 @@ class MetadataProcessor:
                         ),
                         description=TranslatedString(
                             content=original_metadata.description,
+                            language="original",
+                        ),
+                        tagline=TranslatedString(
+                            content=original_metadata.tagline,
                             language="original",
                         ),
                     )
@@ -116,6 +121,7 @@ class MetadataProcessor:
         if (
             metadata_info.title == selected_translation.title.content
             and metadata_info.description == selected_translation.description.content
+            and self._tagline_matches(metadata_info.tagline, selected_translation)
         ):
             return MetadataProcessResult(
                 success=True,
@@ -222,6 +228,7 @@ class MetadataProcessor:
                 if backup_entry and (
                     entry.title != backup_entry.title
                     or entry.description != backup_entry.description
+                    or entry.tagline != backup_entry.tagline
                 ):
                     entry_translation = TranslatedContent(
                         title=TranslatedString(
@@ -229,6 +236,10 @@ class MetadataProcessor:
                         ),
                         description=TranslatedString(
                             content=backup_entry.description,
+                            language="original",
+                        ),
+                        tagline=TranslatedString(
+                            content=backup_entry.tagline,
                             language="original",
                         ),
                     )
@@ -245,6 +256,7 @@ class MetadataProcessor:
             if (
                 entry.title == entry_translation.title.content
                 and entry.description == entry_translation.description.content
+                and self._tagline_matches(entry.tagline, entry_translation)
             ):
                 unchanged_count += 1
                 translated_count += 1
@@ -481,7 +493,19 @@ class MetadataProcessor:
         Returns:
             TranslatedContent with empty fields replaced by original content
         """
-        # If both title and description are present, no fallback needed
+        # A tagline-only translation must leave title and description unchanged.
+        if not translation.title.content and not translation.description.content:
+            return TranslatedContent(
+                title=TranslatedString(
+                    content=metadata_info.title, language="original"
+                ),
+                description=TranslatedString(
+                    content=metadata_info.description, language="original"
+                ),
+                tagline=translation.tagline,
+            )
+
+        # If both title and description are present, no fallback needed.
         if translation.title.content and translation.description.content:
             return translation
 
@@ -509,6 +533,7 @@ class MetadataProcessor:
                             content=metadata_info.description, language="original"
                         )
                     ),
+                    tagline=translation.tagline,
                 )
 
         # Apply fallback using cached original content
@@ -529,6 +554,7 @@ class MetadataProcessor:
         return TranslatedContent(
             title=final_title,
             description=final_description,
+            tagline=translation.tagline,
         )
 
     def _get_original_title_if_language_matches(
@@ -589,6 +615,7 @@ class MetadataProcessor:
             episode=entry.episode,
             title=entry.title,
             description=entry.description,
+            tagline=entry.tagline,
             xml_tree=entry.xml_tree,
         )
 
@@ -628,16 +655,20 @@ class MetadataProcessor:
             raise ValueError("XML tree cannot be None")
 
         root = xml_tree.getroot()
+        if root is None:
+            raise ValueError("XML root cannot be None")
 
         # Update title element
-        title_element = root.find("title")  # type: ignore[union-attr]
+        title_element = root.find("title")
         if title_element is not None:
             title_element.text = translation.title.content
 
         # Update plot/description element
-        plot_element = root.find("plot")  # type: ignore[union-attr]
+        plot_element = root.find("plot")
         if plot_element is not None:
             plot_element.text = translation.description.content
+
+        self._write_tagline(root, translation)
 
         # Write the updated XML back to file atomically
         temp_path = nfo_path.with_suffix(".nfo.tmp")
@@ -683,6 +714,7 @@ class MetadataProcessor:
                     plot_element = root.find("plot")
                     if plot_element is not None:
                         plot_element.text = translation.description.content
+                    self._write_tagline(root, translation)
 
                 ET.indent(xml_tree, space="  ", level=0)
                 serialized_documents.append(ET.tostring(root, encoding="unicode"))
@@ -712,8 +744,9 @@ class MetadataProcessor:
         """
         title_string = None
         description_string = None
+        tagline_string = None
 
-        # Find best title and description from preferred languages
+        # Find best title, description, and tagline from preferred languages.
         for preferred_lang in self.settings.preferred_languages:
             if preferred_lang in all_translations:
                 translation = all_translations[preferred_lang]
@@ -726,23 +759,28 @@ class MetadataProcessor:
                 if not description_string and translation.description.content:
                     description_string = translation.description
 
-                # Stop if we have both title and description
-                if title_string and description_string:
+                if not tagline_string and translation.tagline.content:
+                    tagline_string = translation.tagline
+
+                # Stop if we have all fields.
+                if title_string and description_string and tagline_string:
                     break
 
-        # Return merged translation if we found at least one field
-        if title_string or description_string:
-            # Use empty TranslatedString with "unknown" language for missing fields
+        # Return merged translation if we found at least one field.
+        if title_string or description_string or tagline_string:
+            # Use empty TranslatedString with "unknown" language for missing fields.
             return TranslatedContent(
                 title=title_string or TranslatedString(content="", language="unknown"),
                 description=description_string
+                or TranslatedString(content="", language="unknown"),
+                tagline=tagline_string
                 or TranslatedString(content="", language="unknown"),
             )
 
         return None
 
     def _build_success_message(self, translation: TranslatedContent) -> str:
-        """Build success message showing language sources for title and description.
+        """Build success message showing source languages for translated fields.
 
         Args:
             translation: The selected translation content
@@ -750,15 +788,53 @@ class MetadataProcessor:
         Returns:
             Formatted success message
         """
-        if translation.title.language == translation.description.language:
+        if (
+            translation.title.content
+            and translation.description.content
+            and translation.title.language == translation.description.language
+            and (
+                not translation.tagline.content
+                or translation.tagline.language == translation.title.language
+            )
+        ):
             return f"Successfully translated to {translation.title.language}"
+
+        fields = (
+            ("title", translation.title),
+            ("description", translation.description),
+            ("tagline", translation.tagline),
+        )
+        selected_fields = [(name, value) for name, value in fields if value.content]
+        parts = [f"{name}: {value.language}" for name, value in selected_fields]
+        return f"Successfully translated ({', '.join(parts)})"
+
+    def _tagline_matches(self, tagline: str, translation: TranslatedContent) -> bool:
+        """Return whether a tagline requires no update."""
+        if translation.tagline.content or translation.tagline.language == "original":
+            return tagline == translation.tagline.content
+        return True
+
+    def _write_tagline(self, root: ET.Element, translation: TranslatedContent) -> None:
+        """Replace tagline only when TMDB supplies one or backup restores it."""
+        if (
+            not translation.tagline.content
+            and translation.tagline.language != "original"
+        ):
+            return
+
+        for tagline_element in root.findall("tagline"):
+            root.remove(tagline_element)
+
+        if not translation.tagline.content:
+            return
+
+        tagline_element = ET.Element("tagline")
+        tagline_element.text = translation.tagline.content
+        plot_element = root.find("plot")
+        if plot_element is None:
+            root.append(tagline_element)
         else:
-            parts = []
-            if translation.title.content:
-                parts.append(f"title: {translation.title.language}")
-            if translation.description.content:
-                parts.append(f"description: {translation.description.language}")
-            return f"Successfully translated ({', '.join(parts)})"
+            root.insert(list(root).index(plot_element) + 1, tagline_element)
 
     def _build_multi_episode_message(
         self,

--- a/src/sonarr_metadata_rewrite/models.py
+++ b/src/sonarr_metadata_rewrite/models.py
@@ -1,7 +1,7 @@
 """Data models for sonarr-metadata-rewrite."""
 
 import xml.etree.ElementTree as ET
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Literal
 
@@ -47,6 +47,9 @@ class TranslatedContent:
 
     title: TranslatedString
     description: TranslatedString
+    tagline: TranslatedString = field(
+        default_factory=lambda: TranslatedString(content="", language="unknown")
+    )
 
 
 @dataclass
@@ -66,6 +69,7 @@ class MetadataInfo:
     # Content
     title: str = ""
     description: str = ""
+    tagline: str = ""
 
     # Raw XML for writing
     xml_tree: ET.ElementTree | None = None
@@ -83,6 +87,7 @@ class EpisodeMetadataInfo:
     episode: int | None = None
     title: str = ""
     description: str = ""
+    tagline: str = ""
     xml_tree: ET.ElementTree | None = None
 
 

--- a/src/sonarr_metadata_rewrite/translator.py
+++ b/src/sonarr_metadata_rewrite/translator.py
@@ -157,9 +157,10 @@ class Translator:
             title_key = "title" if media_type == "movie" else "name"
             title = data.get(title_key, "").strip()
             description = data.get("overview", "").strip()
+            tagline = data.get("tagline", "").strip()
 
-            # Skip if both title and description are empty
-            if not title and not description:
+            # Skip records without any localizable metadata.
+            if not title and not description and not tagline:
                 continue
 
             translations[full_language_code] = TranslatedContent(
@@ -167,6 +168,7 @@ class Translator:
                 description=TranslatedString(
                     content=description, language=full_language_code
                 ),
+                tagline=TranslatedString(content=tagline, language=full_language_code),
             )
 
         return translations
@@ -273,16 +275,42 @@ class Translator:
         converted_data = {}
 
         for lang_code, content in cached_data.items():
-            if isinstance(content.title, str):
+            has_tagline = hasattr(content, "tagline")
+            tagline = getattr(
+                content,
+                "tagline",
+                TranslatedString(content="", language="unknown"),
+            )
+            if (
+                isinstance(content.title, str)
+                or not has_tagline
+                or not isinstance(tagline, TranslatedString)
+            ):
                 # Old format - convert to new format
                 converted_content = TranslatedContent(
-                    title=TranslatedString(
-                        content=content.title,
-                        language=getattr(content, "language", lang_code),
+                    title=(
+                        TranslatedString(
+                            content=content.title,
+                            language=getattr(content, "language", lang_code),
+                        )
+                        if isinstance(content.title, str)
+                        else content.title
                     ),
-                    description=TranslatedString(
-                        content=str(content.description),
-                        language=getattr(content, "language", lang_code),
+                    description=(
+                        TranslatedString(
+                            content=str(content.description),
+                            language=getattr(content, "language", lang_code),
+                        )
+                        if isinstance(content.description, str)
+                        else content.description
+                    ),
+                    tagline=(
+                        tagline
+                        if isinstance(tagline, TranslatedString)
+                        else TranslatedString(
+                            content=str(tagline),
+                            language=getattr(content, "language", lang_code),
+                        )
                     ),
                 )
                 converted_data[lang_code] = converted_content

--- a/tests/integration/test_helpers.py
+++ b/tests/integration/test_helpers.py
@@ -158,6 +158,7 @@ def parse_nfo_content(nfo_path: Path) -> dict[str, Any]:
         "root_tag": extracted.file_type,
         "title": extracted.title,
         "plot": extracted.description,
+        "tagline": extracted.tagline,
         "tmdb_id": extracted.tmdb_id,
         "tvdb_id": extracted.tvdb_id,
         "entries": [],
@@ -165,12 +166,20 @@ def parse_nfo_content(nfo_path: Path) -> dict[str, Any]:
 
     if extracted.episode_entries:
         metadata["entries"] = [
-            {"title": entry.title, "plot": entry.description}
+            {
+                "title": entry.title,
+                "plot": entry.description,
+                "tagline": entry.tagline,
+            }
             for entry in extracted.episode_entries
         ]
     else:
         metadata["entries"] = [
-            {"title": extracted.title, "plot": extracted.description}
+            {
+                "title": extracted.title,
+                "plot": extracted.description,
+                "tagline": extracted.tagline,
+            }
         ]
 
     return metadata
@@ -350,6 +359,7 @@ def verify_translations(
     nfo_files: list[Path],
     expected_language: str,
     possible_languages: list[str],
+    require_tagline: bool = True,
 ) -> None:
     """Wait for and verify translation results.
 
@@ -360,6 +370,7 @@ def verify_translations(
                            Must include "en" since Sonarr only generates English
                            metadata files initially, and English text remains if
                            translation fails.
+        require_tagline: Whether a tagline is expected and should be validated.
 
     Raises:
         AssertionError: If files don't match expected state
@@ -422,21 +433,40 @@ def verify_translations(
 
                 return threshold_match, detected_langs
 
+            # Verify tagline status. Single episodes do not have taglines.
+            # English metadata (e.g. original or disabled NFO rewrite) has no tagline.
+            is_episode = metadata.get("root_tag") == "episodedetails"
+            is_english = expected_language == "en"
+
             for entry in metadata.get("entries", []):
                 title = entry.get("title", "").strip()
                 plot = entry.get("plot", "").strip()
+                tagline = entry.get("tagline", "").strip()
 
                 # Ensure we have content to detect
                 assert title, f"NFO file {nfo_file} has no title"
                 assert plot, f"NFO file {nfo_file} has no plot"
 
-                # Detect language in title and plot
+                if is_episode or is_english:
+                    assert not tagline, (
+                        f"Expected empty tagline in {nfo_file.name} for "
+                        f"episode={is_episode}/english={is_english}, got '{tagline}'"
+                    )
+                elif require_tagline:
+                    assert tagline, f"NFO file {nfo_file} has no tagline"
+
+                # Detect language in title, plot, and tagline
                 try:
                     title_matches, title_langs = check_language(title)
                     plot_matches, plot_langs = check_language(plot)
 
-                    # Both title and plot must match
-                    if not (title_matches and plot_matches):
+                    tagline_matches = True
+                    tagline_langs = None
+                    if tagline:
+                        tagline_matches, tagline_langs = check_language(tagline)
+
+                    # Both title and plot must match, tagline must also match if present
+                    if not (title_matches and plot_matches and tagline_matches):
                         error_parts = [
                             f"Language mismatch in {nfo_file.name}. "
                             f"Expected {expected_language}"
@@ -447,15 +477,23 @@ def verify_translations(
                             error_parts.append(f"title_langs={title_langs}")
                         if not plot_matches and plot_langs is not None:
                             error_parts.append(f"plot_langs={plot_langs}")
+                        if not tagline_matches and tagline_langs is not None:
+                            error_parts.append(f"tagline_langs={tagline_langs}")
 
-                        error_parts.extend([f"Title: '{title}'", f"Plot: '{plot}'"])
+                        error_parts.extend(
+                            [
+                                f"Title: '{title}'",
+                                f"Plot: '{plot}'",
+                                f"Tagline: '{tagline}'",
+                            ]
+                        )
 
                         raise AssertionError(". ".join(error_parts))
 
                 except FastLangdetectError as e:
                     raise AssertionError(
                         f"Language detection failed for {nfo_file}: {e}. "
-                        f"Title: '{title}', Plot: '{plot}'"
+                        f"Title: '{title}', Plot: '{plot}', Tagline: '{tagline}'"
                     ) from e
 
     check_translation_state()

--- a/tests/integration/test_sonarr_integration.py
+++ b/tests/integration/test_sonarr_integration.py
@@ -245,6 +245,13 @@ def test_advanced_translation_scenarios(
     else:
         possible_languages.add("zh")
 
+    # For Every Treasure Tells a Story (86965/364698) and Gen V (205715/417909),
+    # TMDB zh-CN has empty taglines, so we allow them to be empty.
+    require_tagline = tvdb_id not in {
+        EVERY_TREASURE_TELLS_A_STORY_TVDB_ID,
+        GEN_V_TVDB_ID,
+    }
+
     with (
         SeriesWithNfos(
             configured_sonarr_container, temp_sonarr_media_root, tvdb_id, images
@@ -258,6 +265,7 @@ def test_advanced_translation_scenarios(
             nfo_files,
             expected_language,
             possible_languages=list(possible_languages),
+            require_tagline=require_tagline,
         )
 
 

--- a/tests/unit/test_metadata_processor.py
+++ b/tests/unit/test_metadata_processor.py
@@ -1858,3 +1858,61 @@ def test_write_translated_episode_entries_requires_xml_tree(
             test_data_dir / "out.nfo",
             {},
         )
+
+
+def test_process_file_no_translation_backup_matches_current(
+    test_data_dir: Path,
+) -> None:
+    """Test early return when backup exists and NFO matches backup."""
+    settings = create_test_settings(
+        test_data_dir,
+        preferred_languages="zh-CN",
+    )
+    mock_translator = Mock(spec=Translator)
+    processor = MetadataProcessor(settings, mock_translator)
+
+    # Create backup with original content
+    nfo_path = test_data_dir / "tvshow.nfo"
+    backup_root = test_data_dir / "backups"
+    backup_path = backup_root / nfo_path.relative_to("/")
+    backup_path.parent.mkdir(parents=True, exist_ok=True)
+    create_custom_nfo(backup_path, "Original Title", "Original plot")
+
+    # Create current NFO with same content as backup (never rewritten)
+    create_custom_nfo(nfo_path, "Original Title", "Original plot")
+
+    # Mock translator returns no preferred language translations
+    mock_translator.get_translations.return_value = {
+        "en": TranslatedContent(
+            title=TranslatedString(content="English Title", language="en"),
+            description=TranslatedString(content="English plot", language="en"),
+        )
+    }
+
+    result = processor.process_file(nfo_path)
+
+    assert_process_result(
+        result,
+        expected_success=False,
+        expected_file_modified=False,
+        expected_message_contains="content already matches original",
+    )
+
+
+def test_write_translated_metadata_with_tree_xml_root_none(
+    processor: MetadataProcessor,
+    test_data_dir: Path,
+) -> None:
+    """Test _write_translated_metadata_with_tree rejects XML tree with no root."""
+    mock_tree = Mock(spec=ET.ElementTree)
+    mock_tree.getroot.return_value = None
+
+    with pytest.raises(ValueError, match="XML root cannot be None"):
+        processor._write_translated_metadata_with_tree(
+            mock_tree,
+            test_data_dir / "out.nfo",
+            TranslatedContent(
+                title=TranslatedString(content="Title", language="en"),
+                description=TranslatedString(content="Plot", language="en"),
+            ),
+        )

--- a/tests/unit/test_metadata_processor.py
+++ b/tests/unit/test_metadata_processor.py
@@ -25,12 +25,13 @@ from tests.conftest import (
 
 
 def translated_content(
-    title: str, description: str, language: str
+    title: str, description: str, language: str, tagline: str = ""
 ) -> TranslatedContent:
     """Create translated content with one language for both fields."""
     return TranslatedContent(
         title=TranslatedString(content=title, language=language),
         description=TranslatedString(content=description, language=language),
+        tagline=TranslatedString(content=tagline, language=language),
     )
 
 
@@ -773,13 +774,20 @@ def test_process_file_single_preferred_language_not_available(
 # Reprocessing Prevention Tests
 
 
-def create_custom_nfo(path: Path, title: str, plot: str, tmdb_id: int = 1396) -> None:
+def create_custom_nfo(
+    path: Path,
+    title: str,
+    plot: str,
+    tmdb_id: int = 1396,
+    tagline: str | None = None,
+) -> None:
     """Helper to create custom .nfo files for reprocessing tests."""
+    tagline_element = f"  <tagline>{tagline}</tagline>\n" if tagline is not None else ""
     content = f"""<?xml version="1.0" encoding="utf-8"?>
 <tvshow>
   <title>{title}</title>
   <plot>{plot}</plot>
-  <uniqueid type="tmdb" default="true">{tmdb_id}</uniqueid>
+{tagline_element}  <uniqueid type="tmdb" default="true">{tmdb_id}</uniqueid>
 </tvshow>
 """
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -795,6 +803,171 @@ def parse_nfo_content(nfo_path: Path) -> tuple[str, str]:
     title = (title_elem.text or "") if title_elem is not None else ""
     plot = (plot_elem.text or "") if plot_elem is not None else ""
     return title, plot
+
+
+def test_process_file_adds_tagline_after_plot(
+    processor: MetadataProcessor,
+    test_data_dir: Path,
+    create_test_files: Callable[[str, Path], Path],
+) -> None:
+    """Test a translated tagline is added after plot when missing from the NFO."""
+    assert isinstance(processor.translator, Mock)
+    processor.translator.get_translations.return_value = {
+        "zh-CN": translated_content(
+            "示例剧集", "这是一个示例描述", "zh-CN", "命运由你掌握。"
+        )
+    }
+    nfo_path = create_test_files("tvshow.nfo", test_data_dir / "tvshow.nfo")
+
+    result = processor.process_file(nfo_path)
+
+    assert result.file_modified is True
+    root = ET.parse(nfo_path).getroot()
+    assert root.findtext("tagline") == "命运由你掌握。"
+    assert [element.tag for element in root].index("tagline") == [
+        element.tag for element in root
+    ].index("plot") + 1
+
+
+def test_process_file_tagline_only_preserves_title_and_plot(
+    processor: MetadataProcessor, test_data_dir: Path
+) -> None:
+    """Test a tagline-only translation leaves title and plot unchanged."""
+    assert isinstance(processor.translator, Mock)
+    processor.translator.get_translations.return_value = {
+        "zh-CN": translated_content("", "", "zh-CN", "命运由你掌握。")
+    }
+    nfo_path = test_data_dir / "tvshow.nfo"
+    create_custom_nfo(
+        nfo_path, "Original Title", "Original plot", tagline="Old tagline"
+    )
+
+    first_result = processor.process_file(nfo_path)
+    second_result = processor.process_file(nfo_path)
+
+    assert first_result.file_modified is True
+    assert second_result.file_modified is False
+    title, plot = parse_nfo_content(nfo_path)
+    assert title == "Original Title"
+    assert plot == "Original plot"
+    assert ET.parse(nfo_path).getroot().findtext("tagline") == "命运由你掌握。"
+
+
+def test_process_file_preserves_tagline_when_tmdb_value_is_empty(
+    processor: MetadataProcessor, test_data_dir: Path
+) -> None:
+    """Test an empty TMDB tagline cannot overwrite the existing NFO value."""
+    assert isinstance(processor.translator, Mock)
+    processor.translator.get_translations.return_value = {
+        "zh-CN": translated_content("中文标题", "中文剧情", "zh-CN")
+    }
+    nfo_path = test_data_dir / "tvshow.nfo"
+    create_custom_nfo(
+        nfo_path, "Original Title", "Original plot", tagline="Old tagline"
+    )
+
+    result = processor.process_file(nfo_path)
+
+    assert result.file_modified is True
+    assert ET.parse(nfo_path).getroot().findtext("tagline") == "Old tagline"
+
+
+def test_process_file_restores_and_removes_added_tagline_from_backup(
+    processor: MetadataProcessor, test_data_dir: Path
+) -> None:
+    """Test restoring a backup without a tagline removes an added tagline."""
+    nfo_path = test_data_dir / "tvshow.nfo"
+    backup_path = test_data_dir / "backups" / nfo_path.relative_to("/")
+    backup_path.parent.mkdir(parents=True, exist_ok=True)
+    create_custom_nfo(backup_path, "Original Title", "Original plot")
+    create_custom_nfo(
+        nfo_path,
+        "中文标题",
+        "中文剧情",
+        tagline="命运由你掌握。",
+    )
+    assert isinstance(processor.translator, Mock)
+    processor.translator.get_translations.return_value = {}
+
+    result = processor.process_file(nfo_path)
+
+    assert result.file_modified is True
+    root = ET.parse(nfo_path).getroot()
+    assert root.findtext("title") == "Original Title"
+    assert root.findtext("plot") == "Original plot"
+    assert root.findall("tagline") == []
+
+
+def test_process_file_episode_adds_tagline(
+    processor: MetadataProcessor,
+    test_data_dir: Path,
+    create_test_files: Callable[[str, Path], Path],
+) -> None:
+    """Test episode NFOs receive non-empty TMDB taglines."""
+    assert isinstance(processor.translator, Mock)
+    processor.translator.get_translations.return_value = {
+        "zh-CN": translated_content(
+            "示例剧集", "这是一个示例描述", "zh-CN", "命运由你掌握。"
+        )
+    }
+    nfo_path = create_test_files("episode.nfo", test_data_dir / "episode.nfo")
+
+    result = processor.process_file(nfo_path)
+
+    assert result.file_modified is True
+    assert ET.parse(nfo_path).getroot().findtext("tagline") == "命运由你掌握。"
+
+
+def test_process_file_replaces_duplicate_taglines(
+    processor: MetadataProcessor, test_data_dir: Path
+) -> None:
+    """Test rewriting collapses duplicate tagline elements into one value."""
+    assert isinstance(processor.translator, Mock)
+    processor.translator.get_translations.return_value = {
+        "zh-CN": translated_content("中文标题", "中文剧情", "zh-CN", "新宣传语")
+    }
+    nfo_path = test_data_dir / "tvshow.nfo"
+    create_custom_nfo(
+        nfo_path, "Original Title", "Original plot", tagline="Old tagline"
+    )
+    nfo_path.write_text(
+        nfo_path.read_text(encoding="utf-8").replace(
+            "  <tagline>Old tagline</tagline>",
+            "  <tagline>Old tagline</tagline>\n  <tagline>Duplicate tagline</tagline>",
+        ),
+        encoding="utf-8",
+    )
+
+    processor.process_file(nfo_path)
+
+    taglines = ET.parse(nfo_path).getroot().findall("tagline")
+    assert len(taglines) == 1
+    assert taglines[0].text == "新宣传语"
+
+
+def test_process_file_appends_tagline_when_plot_is_missing(
+    processor: MetadataProcessor, test_data_dir: Path
+) -> None:
+    """Test a tagline is appended when an NFO has no plot element."""
+    assert isinstance(processor.translator, Mock)
+    processor.translator.get_translations.return_value = {
+        "zh-CN": translated_content("", "", "zh-CN", "命运由你掌握。")
+    }
+    nfo_path = test_data_dir / "tvshow.nfo"
+    nfo_path.write_text(
+        """<tvshow>
+  <title>Original Title</title>
+  <uniqueid type="tmdb">1396</uniqueid>
+</tvshow>
+""",
+        encoding="utf-8",
+    )
+
+    processor.process_file(nfo_path)
+
+    root = ET.parse(nfo_path).getroot()
+    assert root[-1].tag == "tagline"
+    assert root[-1].text == "命运由你掌握。"
 
 
 def test_content_matches_preferred_translation_skips_processing(

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -46,11 +46,13 @@ def test_translated_content() -> None:
     content = TranslatedContent(
         title=TranslatedString(content="示例剧集", language="zh-CN"),
         description=TranslatedString(content="这是一个示例描述", language="zh-CN"),
+        tagline=TranslatedString(content="命运由你掌握。", language="zh-CN"),
     )
     assert content.title.content == "示例剧集"
     assert content.description.content == "这是一个示例描述"
     assert content.title.language == "zh-CN"
     assert content.description.language == "zh-CN"
+    assert content.tagline.content == "命运由你掌握。"
 
 
 def test_process_result() -> None:

--- a/tests/unit/test_translator.py
+++ b/tests/unit/test_translator.py
@@ -53,6 +53,7 @@ def mock_series_response() -> dict[str, Any]:
                 "data": {
                     "name": "测试剧集",
                     "overview": "这是一个测试剧集的描述",
+                    "tagline": "命运由你掌握。",
                     "homepage": "",
                 },
             },
@@ -169,6 +170,7 @@ def test_get_translations_series_success(
     zh_cn = translations["zh-CN"]
     assert zh_cn.title.content == "测试剧集"
     assert zh_cn.description.content == "这是一个测试剧集的描述"
+    assert zh_cn.tagline.content == "命运由你掌握。"
     assert zh_cn.title.language == "zh-CN"
     assert zh_cn.description.language == "zh-CN"
 
@@ -232,7 +234,11 @@ def test_get_translations_movie_uses_movie_path_and_title(
             {
                 "iso_639_1": "zh",
                 "iso_3166_1": "CN",
-                "data": {"title": "电影标题", "overview": "电影剧情"},
+                "data": {
+                    "title": "电影标题",
+                    "overview": "电影剧情",
+                    "tagline": "电影宣传语",
+                },
             }
         ]
     }
@@ -243,6 +249,27 @@ def test_get_translations_movie_uses_movie_path_and_title(
     mock_get.assert_called_once_with("/movie/550/translations", params=None)
     assert translations["zh-CN"].title.content == "电影标题"
     assert translations["zh-CN"].description.content == "电影剧情"
+    assert translations["zh-CN"].tagline.content == "电影宣传语"
+
+
+def test_get_translations_keeps_tagline_only_record(translator: Translator) -> None:
+    """Test translations with only a tagline remain available for selection."""
+    translations = translator._parse_api_translations(
+        {
+            "translations": [
+                {
+                    "iso_639_1": "zh",
+                    "iso_3166_1": "CN",
+                    "data": {"tagline": "命运由你掌握。"},
+                }
+            ]
+        },
+        "movie",
+    )
+
+    assert translations["zh-CN"].title.content == ""
+    assert translations["zh-CN"].description.content == ""
+    assert translations["zh-CN"].tagline.content == "命运由你掌握。"
 
 
 @patch("httpx.Client.get")
@@ -909,6 +936,8 @@ def test_ensure_new_format_backward_compatibility(translator: Translator) -> Non
     assert zh_cn.title.language == "zh-CN"
     assert zh_cn.description.content == "旧格式描述"
     assert zh_cn.description.language == "zh-CN"
+    assert zh_cn.tagline.content == ""
+    assert zh_cn.tagline.language == "unknown"
 
     en_us = converted_data["en-US"]
     assert isinstance(en_us, TranslatedContent)
@@ -928,6 +957,26 @@ def test_ensure_new_format_backward_compatibility(translator: Translator) -> Non
     assert ja.title.language == "ja"
     assert ja.description.content == "新格式描述"
     assert ja.description.language == "ja"
+
+
+def test_ensure_new_format_adds_tagline_to_current_cached_format(
+    translator: Translator,
+) -> None:
+    """Test cached content without tagline gains its default value."""
+    cached_data = {
+        "zh-CN": SimpleNamespace(
+            title=TranslatedString(content="中文标题", language="zh-CN"),
+            description=TranslatedString(content="中文描述", language="zh-CN"),
+        )
+    }
+
+    converted_data = translator._ensure_new_format(cached_data)  # type: ignore[arg-type]
+
+    assert converted_data["zh-CN"].title.content == "中文标题"
+    assert converted_data["zh-CN"].description.content == "中文描述"
+    assert converted_data["zh-CN"].tagline == TranslatedString(
+        content="", language="unknown"
+    )
 
 
 def test_get_translations_cache_backward_compatibility_integration(

--- a/tests/unit/test_translator.py
+++ b/tests/unit/test_translator.py
@@ -356,6 +356,37 @@ def test_get_translations_filters_empty_data(
     assert "zh-CN" not in translations
 
 
+@patch("httpx.Client.get")
+def test_get_translations_skips_entry_without_language_code(
+    mock_get: Mock, translator: Translator
+) -> None:
+    """Test that translation entries with empty language code are skipped (line 150)."""
+    mock_response = Mock()
+    mock_response.raise_for_status.return_value = None
+    mock_response.json.return_value = {
+        "id": 12345,
+        "translations": [
+            {
+                "iso_639_1": "",
+                "iso_3166_1": "CN",
+                "data": {"name": "Some Title", "overview": "Some overview"},
+            },
+            {
+                "iso_639_1": "en",
+                "iso_3166_1": "US",
+                "data": {"name": "Valid Title", "overview": "Valid overview"},
+            },
+        ],
+    }
+    mock_get.return_value = mock_response
+
+    tmdb_ids = TmdbIds(tmdb_id=12345, media_type="tv")
+    translations = translator.get_translations(tmdb_ids)
+
+    assert len(translations) == 1
+    assert "en-US" in translations
+
+
 def test_cache_functionality(
     translator: Translator, mock_series_response: dict[str, Any]
 ) -> None:


### PR DESCRIPTION
## Summary

Extend the metadata translation pipeline to handle the TMDB `tagline` field, covering TV show, movie, and episode NFO files. Tagline is a single-value promotional phrase extracted from the same `/translations` endpoint used for title and plot.

## Key behavior

- **Tagline translated** using existing `preferred_languages` config
- **Empty TMDB tagline** never overwrites existing NFO tagline
- **Missing tagline** added after `<plot>` (or appended to root end if no plot)
- **Multiple tagline elements** collapsed to one on rewrite
- **Episode NFOs**: tagline support added but TMDB episode translations typically lack tagline data, so tagline remains empty after rewrite
- **Backup restore** reverts title/plot/tagline; deletes added tagline if backup had none
- **Old cache** without tagline attribute auto-fills default empty value

## Changes

- `TranslatedContent` extended with `tagline: TranslatedString` (default empty)
- `translator.py`: parse `data.tagline` from TMDB `/translations`; skip records where title+description+tagline all empty; old cache compat
- `metadata_processor.py`: independent lang preference merge for tagline; `_tagline_matches`/`_write_tagline` helpers; tagline-only translation preserves title/plot; backup restore deletes added tagline
- `file_utils.py`: NFO tagline extraction
- Unit tests: tagline selection, preservation, restore, episode, duplicates, no-plot (322 passed)
- Integration tests: real TMDB data across 15 root NFOs, 14 episode NFOs, rollback, edge cases (16 passed)