### PR TITLE
[test] stabilize Arr integration fixtures

### DIFF
--- a/tests/integration/fixtures/arr_client.py
+++ b/tests/integration/fixtures/arr_client.py
@@ -80,6 +80,69 @@ class ArrClient:
             )
         return True
 
+    def _wait_for_queued_command(
+        self,
+        command_name: str,
+        resource_id_field: str,
+        resource_id: int,
+        timeout: float = 30.0,
+    ) -> None:
+        """Wait for an Arr command queued automatically for one resource."""
+
+        @retry(
+            timeout=timeout,
+            interval=0.5,
+            log_interval=2.0,
+            exceptions=(AssertionError, httpx.RequestError),
+        )
+        def check_command() -> None:
+            response = self._make_request("GET", "/api/v3/command")
+            response.raise_for_status()
+            matching_commands = [
+                command
+                for command in response.json()
+                if command.get("name", "").lower() == command_name.lower()
+                and resource_id in command.get("body", {}).get(resource_id_field, [])
+            ]
+            assert matching_commands, (
+                f"{command_name} command for {resource_id} not queued yet"
+            )
+            command = max(matching_commands, key=lambda item: item["id"])
+            self._assert_command_completed(command)
+
+        check_command()
+
+    def _wait_for_command(self, command_id: int, timeout: float = 30.0) -> None:
+        """Wait for one Arr command to complete successfully."""
+
+        @retry(
+            timeout=timeout,
+            interval=0.5,
+            log_interval=2.0,
+            exceptions=(AssertionError, httpx.RequestError),
+        )
+        def check_command() -> None:
+            response = self._make_request("GET", f"/api/v3/command/{command_id}")
+            response.raise_for_status()
+            self._assert_command_completed(response.json())
+
+        check_command()
+
+    def _assert_command_completed(self, command: dict[str, Any]) -> None:
+        """Validate command state, retrying active commands via AssertionError."""
+        status = str(command.get("status", "")).lower()
+        if status == "completed":
+            return
+        if status in {"failed", "aborted"}:
+            raise RuntimeError(
+                f"{self.service_name} command {command.get('id')} ended with status "
+                f"{status}: {command.get('message', '')}"
+            )
+        raise AssertionError(
+            f"{self.service_name} command {command.get('id')} still has status "
+            f"{status or 'unknown'}"
+        )
+
     def close(self) -> None:
         """Close the HTTP client."""
         self.client.close()

--- a/tests/integration/fixtures/arr_client.py
+++ b/tests/integration/fixtures/arr_client.py
@@ -128,6 +128,49 @@ class ArrClient:
 
         check_command()
 
+    def _configure_metadata_settings(
+        self, provider_names: tuple[str, ...], field_values: dict[str, bool]
+    ) -> bool:
+        """Enable one metadata provider after Arr finishes registering it."""
+
+        @retry(timeout=30.0, interval=0.5, log_interval=2.0)
+        def get_provider() -> dict[str, Any]:
+            response = self._make_request("GET", "/api/v3/metadata")
+            response.raise_for_status()
+            provider = next(
+                (
+                    config
+                    for config in response.json()
+                    if any(
+                        name in config.get("name", "").lower()
+                        for name in provider_names
+                    )
+                    and set(field_values).issubset(
+                        {
+                            field.get("name", "").lower()
+                            for field in config.get("fields", [])
+                        }
+                    )
+                ),
+                None,
+            )
+            assert provider is not None, (
+                f"{self.service_name} metadata providers are not initialized yet"
+            )
+            return cast(dict[str, Any], provider)
+
+        provider = get_provider()
+        provider["enable"] = True
+        for field in provider.get("fields", []):
+            field_name = field.get("name", "").lower()
+            if field_name in field_values:
+                field["value"] = field_values[field_name]
+
+        response = self._make_request(
+            "PUT", f"/api/v3/metadata/{provider['id']}", json=provider
+        )
+        return response.is_success
+
     def _assert_command_completed(self, command: dict[str, Any]) -> None:
         """Validate command state, retrying active commands via AssertionError."""
         status = str(command.get("status", "")).lower()

--- a/tests/integration/fixtures/radarr_client.py
+++ b/tests/integration/fixtures/radarr_client.py
@@ -3,6 +3,7 @@
 from pathlib import Path
 from typing import Any, cast
 
+from sonarr_metadata_rewrite.retry_utils import retry
 from tests.integration.fixtures.arr_client import ArrClient
 
 
@@ -40,7 +41,11 @@ class RadarrClient(ArrClient):
         )
         response = self._make_request("POST", "/api/v3/movie", json=movie_data)
         response.raise_for_status()
-        return cast(dict[str, Any], response.json())
+        added_movie = cast(dict[str, Any], response.json())
+        self._wait_for_queued_command(
+            "RefreshMovie", "movieIds", cast(int, added_movie["id"])
+        )
+        return added_movie
 
     def ensure_root_folder(self, root_folder: str) -> None:
         """Register mounted movie root when Radarr has not seen it yet."""
@@ -58,7 +63,12 @@ class RadarrClient(ArrClient):
         response = self._make_request(
             "POST", "/api/v3/command", json={"name": "RescanMovie", "movieId": movie_id}
         )
-        return response.status_code in (200, 201)
+        if response.status_code not in (200, 201):
+            return False
+
+        command = cast(dict[str, Any], response.json())
+        self._wait_for_command(cast(int, command["id"]))
+        return True
 
     def get_movie(self, movie_id: int) -> dict[str, Any]:
         """Get movie details, including imported file state."""
@@ -68,36 +78,39 @@ class RadarrClient(ArrClient):
 
     def configure_metadata_settings(self, use_movie_nfo: bool) -> bool:
         """Enable Kodi/Emby movie metadata and images for selected NFO mode."""
-        response = self._make_request("GET", "/api/v3/metadata")
-        response.raise_for_status()
-        metadata_configs = response.json()
         field_values = {
             "moviemetadata": True,
             "movieimages": True,
             "usemovienfo": use_movie_nfo,
         }
-        provider = next(
-            (
-                config
-                for config in metadata_configs
-                if any(
-                    name in config.get("name", "").lower()
-                    for name in ("kodi", "xbmc", "emby")
-                )
-                and set(field_values).issubset(
-                    {
-                        field.get("name", "").lower()
-                        for field in config.get("fields", [])
-                    }
-                )
-            ),
-            None,
-        )
-        if provider is None:
-            raise ValueError(
-                "No Kodi/XBMC/Emby metadata provider supports movieMetadata, "
-                "movieImages, and UseMovieNfo"
+
+        @retry(timeout=30.0, interval=0.5, log_interval=2.0)
+        def get_provider() -> dict[str, Any]:
+            response = self._make_request("GET", "/api/v3/metadata")
+            response.raise_for_status()
+            provider = next(
+                (
+                    config
+                    for config in response.json()
+                    if any(
+                        name in config.get("name", "").lower()
+                        for name in ("kodi", "xbmc", "emby")
+                    )
+                    and set(field_values).issubset(
+                        {
+                            field.get("name", "").lower()
+                            for field in config.get("fields", [])
+                        }
+                    )
+                ),
+                None,
             )
+            assert provider is not None, (
+                "Radarr metadata providers are not initialized yet"
+            )
+            return cast(dict[str, Any], provider)
+
+        provider = get_provider()
         provider["enable"] = True
         for field in provider["fields"]:
             field_name = field.get("name", "").lower()

--- a/tests/integration/fixtures/radarr_client.py
+++ b/tests/integration/fixtures/radarr_client.py
@@ -3,7 +3,6 @@
 from pathlib import Path
 from typing import Any, cast
 
-from sonarr_metadata_rewrite.retry_utils import retry
 from tests.integration.fixtures.arr_client import ArrClient
 
 
@@ -78,49 +77,14 @@ class RadarrClient(ArrClient):
 
     def configure_metadata_settings(self, use_movie_nfo: bool) -> bool:
         """Enable Kodi/Emby movie metadata and images for selected NFO mode."""
-        field_values = {
-            "moviemetadata": True,
-            "movieimages": True,
-            "usemovienfo": use_movie_nfo,
-        }
-
-        @retry(timeout=30.0, interval=0.5, log_interval=2.0)
-        def get_provider() -> dict[str, Any]:
-            response = self._make_request("GET", "/api/v3/metadata")
-            response.raise_for_status()
-            provider = next(
-                (
-                    config
-                    for config in response.json()
-                    if any(
-                        name in config.get("name", "").lower()
-                        for name in ("kodi", "xbmc", "emby")
-                    )
-                    and set(field_values).issubset(
-                        {
-                            field.get("name", "").lower()
-                            for field in config.get("fields", [])
-                        }
-                    )
-                ),
-                None,
-            )
-            assert provider is not None, (
-                "Radarr metadata providers are not initialized yet"
-            )
-            return cast(dict[str, Any], provider)
-
-        provider = get_provider()
-        provider["enable"] = True
-        for field in provider["fields"]:
-            field_name = field.get("name", "").lower()
-            if field_name in field_values:
-                field["value"] = field_values[field_name]
-
-        response = self._make_request(
-            "PUT", f"/api/v3/metadata/{provider['id']}", json=provider
+        return self._configure_metadata_settings(
+            provider_names=("kodi", "xbmc", "emby"),
+            field_values={
+                "moviemetadata": True,
+                "movieimages": True,
+                "usemovienfo": use_movie_nfo,
+            },
         )
-        return response.is_success
 
     def remove_movie(
         self,

--- a/tests/integration/fixtures/sonarr_client.py
+++ b/tests/integration/fixtures/sonarr_client.py
@@ -112,51 +112,16 @@ class SonarrClient(ArrClient):
         Returns:
             True if configuration was successful
         """
-        # Get existing metadata settings
-        response = self._make_request("GET", "/api/v3/metadata")
-        if not response.is_success:
-            print(f"Failed to get metadata settings: {response.status_code}")
-            return False
-
-        metadata_configs = response.json()
-
-        # Look for Kodi/XBMC metadata provider and enable it
-        kodi_config = None
-        for config in metadata_configs:
-            config_name = config.get("name", "").lower()
-            if any(name in config_name for name in ["kodi", "xbmc"]):
-                kodi_config = config
-                break
-
-        if not kodi_config:
-            raise ValueError("No Kodi/XBMC metadata provider found")
-
-        # Enable the provider itself
-        kodi_config["enable"] = True
-
-        # Update the individual field values in the fields array
-        for field in kodi_config.get("fields", []):
-            field_name = field.get("name")
-            if field_name in [
-                "seriesMetadata",
-                "episodeMetadata",
-                "episodeImages",
-                "seriesImages",
-                "seasonImages",
-            ]:
-                field["value"] = True
-
-        # Update the configuration
-        response = self._make_request(
-            "PUT", f"/api/v3/metadata/{kodi_config['id']}", json=kodi_config
+        return self._configure_metadata_settings(
+            provider_names=("kodi", "xbmc"),
+            field_values={
+                "seriesmetadata": True,
+                "episodemetadata": True,
+                "episodeimages": True,
+                "seriesimages": True,
+                "seasonimages": True,
+            },
         )
-
-        if response.is_success:
-            return True
-        else:
-            print(f"Failed to update metadata settings: {response.status_code}")
-            print(f"Response body: {response.text}")
-            return False
 
     def remove_series(
         self,

--- a/tests/integration/fixtures/sonarr_client.py
+++ b/tests/integration/fixtures/sonarr_client.py
@@ -59,7 +59,11 @@ class SonarrClient(ArrClient):
 
         response = self._make_request("POST", "/api/v3/series", json=add_data)
         response.raise_for_status()
-        return cast(dict[str, Any], response.json())
+        added_series = cast(dict[str, Any], response.json())
+        self._wait_for_queued_command(
+            "RefreshSeries", "seriesIds", cast(int, added_series["id"])
+        )
+        return added_series
 
     def trigger_disk_scan(self, series_id: int) -> bool:
         """Trigger a disk scan for episode files.
@@ -76,7 +80,12 @@ class SonarrClient(ArrClient):
         }
 
         response = self._make_request("POST", "/api/v3/command", json=command_data)
-        return response.status_code in (200, 201)
+        if response.status_code not in (200, 201):
+            return False
+
+        command = cast(dict[str, Any], response.json())
+        self._wait_for_command(cast(int, command["id"]))
+        return True
 
     def get_episode_files(self, series_id: int) -> list[dict[str, Any]]:
         """Get episode files for a series to verify imports.

--- a/tests/integration/test_helpers.py
+++ b/tests/integration/test_helpers.py
@@ -1,6 +1,7 @@
 """Helper functions for integration tests."""
 
 import shutil
+from contextlib import ExitStack
 from pathlib import Path
 from typing import Any, cast
 
@@ -211,6 +212,7 @@ class SeriesWithNfos:
         self.expected_image_filenames = expected_image_filenames
         self.episodes = episodes or [("Episode 1", 1, 1), ("Episode 2", 1, 2)]
         self.series: SeriesManager | None = None
+        self._stack: ExitStack | None = None
 
     def __enter__(self) -> tuple[list[Path], list[Path]]:
         """Set up series and return series info.
@@ -218,48 +220,44 @@ class SeriesWithNfos:
         Returns:
             Tuple of (nfo_files, image_files)
         """
-        self.series = SeriesManager(self.sonarr, self.tvdb_id, "/tv", self.media_root)
-        self.series.__enter__()
-
-        # Create fake episode files to trigger Sonarr processing
-        episode_files = []
-        for title, season, episode in self.episodes:
-            episode_file = create_fake_episode_file(
-                self.media_root, self.series.slug, season, episode, title
+        with ExitStack() as stack:
+            self.series = stack.enter_context(
+                SeriesManager(self.sonarr, self.tvdb_id, "/tv", self.media_root)
             )
-            episode_files.append(episode_file)
 
-        # Trigger disk scan to detect episode files
-        series_path = self.media_root / self.series.slug
-        scan_success = self.sonarr.trigger_disk_scan(self.series.id)
-        if not scan_success:
-            raise RuntimeError("Failed to trigger disk scan")
+            # Create fake episode files to trigger Sonarr processing
+            episode_files = []
+            for title, season, episode in self.episodes:
+                episode_file = create_fake_episode_file(
+                    self.media_root, self.series.slug, season, episode, title
+                )
+                episode_files.append(episode_file)
 
-        # Wait for disk scan to complete and import files
-        @retry(timeout=15.0, interval=1.0, log_interval=2.0)
-        def check_disk_scan_complete() -> None:
-            assert self.series is not None
+            # Trigger disk scan to detect episode files and wait for it to finish
+            series_path = self.media_root / self.series.slug
+            scan_success = self.sonarr.trigger_disk_scan(self.series.id)
+            if not scan_success:
+                raise RuntimeError("Failed to trigger disk scan")
+
             imported_files = self.sonarr.get_episode_files(self.series.id)
             assert len(imported_files) >= len(episode_files), (
-                f"Disk scan still in progress: expected {len(episode_files)} "
-                f"episode files, but only {len(imported_files)} imported so far"
+                f"Expected {len(episode_files)} imported episode files after scan, "
+                f"but found {len(imported_files)}"
             )
 
-        check_disk_scan_complete()
+            # NFO files are generated automatically during series/episode import
+            expected_nfo_count = len(episode_files) + 1  # episodes + series
+            nfo_files = wait_for_nfo_files(
+                series_path, expected_nfo_count, timeout=30.0
+            )
 
-        # NFO files are generated automatically during series/episode import
-
-        # Wait for .nfo files to be generated
-        expected_nfo_count = len(episode_files) + 1  # episodes + series
-        series_path = self.media_root / self.series.slug
-        nfo_files = wait_for_nfo_files(series_path, expected_nfo_count, timeout=30.0)
-
-        return nfo_files, [series_path / f for f in self.expected_image_filenames]
+            self._stack = stack.pop_all()
+            return nfo_files, [series_path / f for f in self.expected_image_filenames]
 
     def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
         """Clean up series."""
-        if self.series:
-            self.series.__exit__(exc_type, exc_val, exc_tb)
+        if self._stack:
+            self._stack.__exit__(exc_type, exc_val, exc_tb)
 
 
 class MovieWithNfos:
@@ -278,46 +276,54 @@ class MovieWithNfos:
         self.tmdb_id = tmdb_id
         self.use_movie_nfo = use_movie_nfo
         self.movie: MovieManager | None = None
+        self._stack: ExitStack | None = None
 
     def __enter__(self) -> tuple[Path, list[Path]]:
         """Import movie and return Radarr-created NFO and artwork paths."""
-        self.movie = MovieManager(self.radarr, self.tmdb_id, "/movies", self.media_root)
-        self.movie.__enter__()
-        movie_file = create_fake_movie_file(self.movie)
-        if not self.radarr.trigger_disk_scan(self.movie.id):
-            raise RuntimeError("Failed to trigger Radarr disk scan")
+        with ExitStack() as stack:
+            self.movie = stack.enter_context(
+                MovieManager(self.radarr, self.tmdb_id, "/movies", self.media_root)
+            )
+            movie_file = create_fake_movie_file(self.movie)
+            if not self.radarr.trigger_disk_scan(self.movie.id):
+                raise RuntimeError("Failed to trigger Radarr disk scan")
 
-        @retry(timeout=30.0, interval=1.0, log_interval=2.0)
-        def wait_for_import() -> None:
-            assert self.movie is not None
-            movie_data = self.radarr.get_movie(self.movie.id)
-            assert movie_data.get("hasFile"), "Radarr scan has not imported movie file"
+            @retry(timeout=30.0, interval=1.0, log_interval=2.0)
+            def wait_for_import() -> None:
+                assert self.movie is not None
+                movie_data = self.radarr.get_movie(self.movie.id)
+                assert movie_data.get("hasFile"), (
+                    "Radarr scan has not imported movie file"
+                )
 
-        wait_for_import()
-        nfo_file = (
-            self.movie.directory / "movie.nfo"
-            if self.use_movie_nfo
-            else movie_file.with_suffix(".nfo")
-        )
-        image_files = [
-            self.movie.directory / "poster.jpg",
-        ]
-        # Radarr's current TMDB metadata output creates poster/fanart but not
-        # clearlogo. Movie clearlogo rewriting remains covered by unit tests.
+            wait_for_import()
+            nfo_file = (
+                self.movie.directory / "movie.nfo"
+                if self.use_movie_nfo
+                else movie_file.with_suffix(".nfo")
+            )
+            image_files = [
+                self.movie.directory / "poster.jpg",
+            ]
+            # Radarr's current TMDB metadata output creates poster/fanart but not
+            # clearlogo. Movie clearlogo rewriting remains covered by unit tests.
 
-        @retry(timeout=30.0, interval=0.5, log_interval=2.0)
-        def wait_for_radarr_assets() -> None:
-            assert nfo_file.exists(), f"Radarr did not create NFO: {nfo_file}"
-            for image_file in image_files:
-                assert image_file.exists(), f"Radarr did not create image: {image_file}"
+            @retry(timeout=30.0, interval=0.5, log_interval=2.0)
+            def wait_for_radarr_assets() -> None:
+                assert nfo_file.exists(), f"Radarr did not create NFO: {nfo_file}"
+                for image_file in image_files:
+                    assert image_file.exists(), (
+                        f"Radarr did not create image: {image_file}"
+                    )
 
-        wait_for_radarr_assets()
-        return nfo_file, image_files
+            wait_for_radarr_assets()
+            self._stack = stack.pop_all()
+            return nfo_file, image_files
 
     def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
         """Remove Radarr movie and generated files."""
-        if self.movie:
-            self.movie.__exit__(exc_type, exc_val, exc_tb)
+        if self._stack:
+            self._stack.__exit__(exc_type, exc_val, exc_tb)
 
 
 class ServiceRunner:

--- a/tests/unit/test_integration_fixtures.py
+++ b/tests/unit/test_integration_fixtures.py
@@ -43,33 +43,66 @@ def test_arr_command_failure_is_not_retried(
         client.close()
 
 
-def test_radarr_metadata_configuration_waits_for_provider() -> None:
-    """Wait until Radarr finishes registering metadata providers."""
-    client = RadarrClient("http://radarr.invalid")
-    provider = {
-        "id": 4,
-        "name": "Kodi (XMBC) / Emby",
-        "fields": [
-            {"name": "movieMetadata", "value": False},
-            {"name": "movieImages", "value": False},
-            {"name": "UseMovieNfo", "value": False},
-        ],
-    }
-    responses = [
-        httpx.Response(200, json=[], request=httpx.Request("GET", "http://radarr")),
-        httpx.Response(
-            200, json=[provider], request=httpx.Request("GET", "http://radarr")
+@pytest.mark.parametrize(
+    ("client_class", "provider", "is_radarr"),
+    [
+        (
+            RadarrClient,
+            {
+                "id": 4,
+                "name": "Kodi (XMBC) / Emby",
+                "fields": [
+                    {"name": "movieMetadata", "value": False},
+                    {"name": "movieImages", "value": False},
+                    {"name": "UseMovieNfo", "value": False},
+                ],
+            },
+            True,
         ),
-        httpx.Response(202, request=httpx.Request("PUT", "http://radarr")),
+        (
+            SonarrClient,
+            {
+                "id": 5,
+                "name": "Kodi (XBMC)",
+                "fields": [
+                    {"name": "seriesMetadata", "value": False},
+                    {"name": "episodeMetadata", "value": False},
+                    {"name": "episodeImages", "value": False},
+                    {"name": "seriesImages", "value": False},
+                    {"name": "seasonImages", "value": False},
+                ],
+            },
+            False,
+        ),
+    ],
+)
+def test_arr_metadata_configuration_waits_for_provider(
+    client_class: type[RadarrClient] | type[SonarrClient],
+    provider: dict[str, Any],
+    is_radarr: bool,
+) -> None:
+    """Wait until either Arr platform finishes registering metadata providers."""
+    client = client_class("http://arr.invalid")
+    responses = [
+        httpx.Response(200, json=[], request=httpx.Request("GET", "http://arr")),
+        httpx.Response(
+            200, json=[provider], request=httpx.Request("GET", "http://arr")
+        ),
+        httpx.Response(202, request=httpx.Request("PUT", "http://arr")),
     ]
     make_request = MagicMock(side_effect=responses)
 
     try:
         with (
-            patch("tests.integration.fixtures.radarr_client.retry", immediate_retry),
+            patch("tests.integration.fixtures.arr_client.retry", immediate_retry),
             patch.object(client, "_make_request", make_request),
         ):
-            assert client.configure_metadata_settings(use_movie_nfo=True)
+            if is_radarr:
+                assert isinstance(client, RadarrClient)
+                assert client.configure_metadata_settings(use_movie_nfo=True)
+            else:
+                assert isinstance(client, SonarrClient)
+                assert client.configure_metadata_settings()
     finally:
         client.close()
 

--- a/tests/unit/test_integration_fixtures.py
+++ b/tests/unit/test_integration_fixtures.py
@@ -1,0 +1,117 @@
+"""Unit tests for integration fixture lifecycle and readiness behavior."""
+
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any, cast
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+from tests.integration.fixtures.radarr_client import RadarrClient
+from tests.integration.fixtures.sonarr_client import SonarrClient
+from tests.integration.test_helpers import MovieWithNfos, SeriesWithNfos
+
+
+def immediate_retry(**_kwargs: Any) -> Callable[[Callable[[], Any]], Callable[[], Any]]:
+    """Retry twice without sleeping for deterministic fixture tests."""
+
+    def decorator(function: Callable[[], Any]) -> Callable[[], Any]:
+        def wrapper() -> Any:
+            try:
+                return function()
+            except AssertionError:
+                return function()
+
+        return wrapper
+
+    return decorator
+
+
+@pytest.mark.parametrize("client_class", [SonarrClient, RadarrClient])
+def test_arr_command_failure_is_not_retried(
+    client_class: type[SonarrClient] | type[RadarrClient],
+) -> None:
+    """Fail fast when either Arr platform reports a terminal command failure."""
+    client = client_class("http://arr.invalid")
+    try:
+        with pytest.raises(RuntimeError, match="ended with status failed"):
+            client._assert_command_completed(
+                {"id": 12, "status": "failed", "message": "scan failed"}
+            )
+    finally:
+        client.close()
+
+
+def test_radarr_metadata_configuration_waits_for_provider() -> None:
+    """Wait until Radarr finishes registering metadata providers."""
+    client = RadarrClient("http://radarr.invalid")
+    provider = {
+        "id": 4,
+        "name": "Kodi (XMBC) / Emby",
+        "fields": [
+            {"name": "movieMetadata", "value": False},
+            {"name": "movieImages", "value": False},
+            {"name": "UseMovieNfo", "value": False},
+        ],
+    }
+    responses = [
+        httpx.Response(200, json=[], request=httpx.Request("GET", "http://radarr")),
+        httpx.Response(
+            200, json=[provider], request=httpx.Request("GET", "http://radarr")
+        ),
+        httpx.Response(202, request=httpx.Request("PUT", "http://radarr")),
+    ]
+    make_request = MagicMock(side_effect=responses)
+
+    try:
+        with (
+            patch("tests.integration.fixtures.radarr_client.retry", immediate_retry),
+            patch.object(client, "_make_request", make_request),
+        ):
+            assert client.configure_metadata_settings(use_movie_nfo=True)
+    finally:
+        client.close()
+
+    update_payload = cast(dict[str, Any], make_request.call_args.kwargs["json"])
+    assert update_payload["enable"] is True
+    assert all(field["value"] is True for field in update_payload["fields"])
+
+
+def test_series_setup_failure_removes_added_series(tmp_path: Path) -> None:
+    """Clean up Sonarr resource when setup fails inside __enter__."""
+    sonarr = MagicMock(spec=SonarrClient)
+    manager = MagicMock()
+    manager.__enter__.return_value = manager
+    manager.slug = "series"
+    manager.id = 7
+    sonarr.trigger_disk_scan.return_value = False
+
+    with (
+        patch("tests.integration.test_helpers.SeriesManager", return_value=manager),
+        pytest.raises(RuntimeError, match="Failed to trigger disk scan"),
+    ):
+        SeriesWithNfos(sonarr, tmp_path, 1, []).__enter__()
+
+    manager.__exit__.assert_called_once()
+
+
+def test_movie_setup_failure_removes_added_movie(tmp_path: Path) -> None:
+    """Clean up Radarr resource when setup fails inside __enter__."""
+    radarr = MagicMock(spec=RadarrClient)
+    manager = MagicMock()
+    manager.__enter__.return_value = manager
+    manager.directory = tmp_path / "movie"
+    manager.title = "Movie"
+    manager.data = {"year": 2000}
+    manager.id = 8
+    radarr.trigger_disk_scan.return_value = False
+
+    with (
+        patch("tests.integration.test_helpers.MovieManager", return_value=manager),
+        patch("tests.integration.test_helpers.create_fake_movie_file"),
+        pytest.raises(RuntimeError, match="Failed to trigger Radarr disk scan"),
+    ):
+        MovieWithNfos(radarr, tmp_path, 1, use_movie_nfo=True).__enter__()
+
+    manager.__exit__.assert_called_once()


### PR DESCRIPTION
## Summary

- wait for Sonarr and Radarr refresh and disk scan commands to finish before integration setup continues
- wait for Radarr metadata providers to initialize before configuring NFO output
- clean up partially created series and movies when fixture setup fails
- add focused unit coverage for command terminal states, provider readiness, and setup cleanup

## Testing

- `./scripts/run-unit-tests.sh` (330 passed)
- `./scripts/lint.sh --check`
- `npx jscpd` (0 clones)
- `./scripts/run-integration-tests.sh` (16 passed)
- repeat integration run: 6 consecutive runs passed; run 7 reached 15/16 before an external TMDB image request failed with `SSL: UNEXPECTED_EOF_WHILE_READING`