### PR TITLE
[fix] cache raw TMDB responses

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -26,3 +26,51 @@ _Avoid_: Source application
 **Artwork Kind**:
 The local artwork category selected for rewriting: poster or clearlogo.
 _Avoid_: Image type
+
+**TMDB Response Cache**:
+Persistent local cache of the JSON representation returned for one canonical
+TMDB GET request. It stores provider data, not derived translation content.
+_Avoid_: Translation cache, cached TranslatedContent
+
+**Canonical TMDB Request**:
+Stable identity of a request for one TMDB representation based on its method,
+path, and query parameters. It does not distinguish request headers,
+credentials, or local selection preferences.
+_Avoid_: Endpoint-specific cache key, request path alone, header-variant key
+
+**TMDB JSON Representation**:
+JSON document returned by TMDB for a Canonical TMDB Request. It is provider
+data, not an HTTP client response or derived translation content.
+_Avoid_: httpx.Response, TranslatedContent
+
+**Cacheable TMDB Outcome**:
+A JSON representation returned with status 200, or an explicit not-found
+result, for a Canonical TMDB Request. All other HTTP and network failures are
+not cacheable outcomes.
+_Avoid_: Cached client error, cached rate-limit response, cached server error
+
+**TMDB Cache Lifetime**:
+Period during which a Cacheable TMDB Outcome is authoritative locally. It
+applies uniformly to all cacheable outcomes.
+_Avoid_: Endpoint-specific cache lifetime
+
+**TMDB Response Cache Namespace Version**:
+Version identifying a TMDB Response Cache contract. It changes only when the
+cache payload or Canonical TMDB Request semantics become incompatible.
+_Avoid_: Parser version, application release version
+
+**Cacheable TMDB Read**:
+An idempotent TMDB GET operation whose provider data uses the TMDB Response
+Cache. Translation, details, image, and external-ID reads are cacheable TMDB
+reads.
+_Avoid_: Cached derived translation, image-selection, or details result
+
+**Lazy Cache Reclamation**:
+Deferred physical removal of expired cache entries. Expiration makes an
+outcome unavailable immediately; later cache writes reclaim its storage.
+_Avoid_: Serving expired outcomes, timed cache purge
+
+**Canonical Query Parameters**:
+Stable query representation for a Canonical TMDB Request. Equivalent request
+parameters identify one provider representation regardless of input ordering.
+_Avoid_: Endpoint-specific query key, input-order-dependent query

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -28,24 +28,25 @@ The local artwork category selected for rewriting: poster or clearlogo.
 _Avoid_: Image type
 
 **TMDB Response Cache**:
-Persistent local cache of the JSON representation returned for one canonical
-TMDB GET request. It stores provider data, not derived translation content.
+Persistent local cache of the JSON representation returned for one
+HTTPX-serialized TMDB GET URL. It stores provider data, not derived translation
+content.
 _Avoid_: Translation cache, cached TranslatedContent
 
-**Canonical TMDB Request**:
-Stable identity of a request for one TMDB representation based on its method,
-path, and query parameters. It does not distinguish request headers,
-credentials, or local selection preferences.
+**TMDB Request Identity**:
+Stable identity of a request for one TMDB representation based on its HTTP
+method and fully serialized URL, built by HTTPX before dispatch. It does not
+distinguish request headers, credentials, or local selection preferences.
 _Avoid_: Endpoint-specific cache key, request path alone, header-variant key
 
 **TMDB JSON Representation**:
-JSON document returned by TMDB for a Canonical TMDB Request. It is provider
+JSON document returned by TMDB for a TMDB Request Identity. It is provider
 data, not an HTTP client response or derived translation content.
 _Avoid_: httpx.Response, TranslatedContent
 
 **Cacheable TMDB Outcome**:
 A JSON representation returned with status 200, or an explicit not-found
-result, for a Canonical TMDB Request. All other HTTP and network failures are
+result, for a TMDB Request Identity. All other HTTP and network failures are
 not cacheable outcomes.
 _Avoid_: Cached client error, cached rate-limit response, cached server error
 
@@ -56,7 +57,7 @@ _Avoid_: Endpoint-specific cache lifetime
 
 **TMDB Response Cache Namespace Version**:
 Version identifying a TMDB Response Cache contract. It changes only when the
-cache payload or Canonical TMDB Request semantics become incompatible.
+cache payload or TMDB Request Identity semantics become incompatible.
 _Avoid_: Parser version, application release version
 
 **Cacheable TMDB Read**:
@@ -69,8 +70,3 @@ _Avoid_: Cached derived translation, image-selection, or details result
 Deferred physical removal of expired cache entries. Expiration makes an
 outcome unavailable immediately; later cache writes reclaim its storage.
 _Avoid_: Serving expired outcomes, timed cache purge
-
-**Canonical Query Parameters**:
-Stable query representation for a Canonical TMDB Request. Equivalent request
-parameters identify one provider representation regardless of input ordering.
-_Avoid_: Endpoint-specific query key, input-order-dependent query

--- a/docs/adr/0001-tmdb-response-cache.md
+++ b/docs/adr/0001-tmdb-response-cache.md
@@ -1,0 +1,21 @@
+# Cache TMDB Provider JSON Responses
+
+**Status:** Accepted
+
+Cache every idempotent TMDB read as provider JSON for a versioned canonical
+GET request, rather than caching parsed application models. This prevents a
+parser change, such as adding `tagline`, from treating absent fields in an old
+cached model as authoritative data while preserving reuse across parser-only
+releases.
+
+## Consequences
+
+- Cache only 200 responses and 404 outcomes, using one configured lifetime.
+  Other HTTP outcomes and network failures are never cached.
+- Request identity uses method, path, and canonical query parameters. Headers
+  are outside the initial cache contract.
+- Change the cache namespace only when provider JSON storage or request
+  identity semantics become incompatible. Legacy entries are ignored and
+  reclaimed through DiskCache's lazy expiry lifecycle.
+- Do not add request single-flight coordination until duplicate TMDB traffic
+  becomes a demonstrated operational problem.

--- a/docs/adr/0001-tmdb-response-cache.md
+++ b/docs/adr/0001-tmdb-response-cache.md
@@ -2,18 +2,19 @@
 
 **Status:** Accepted
 
-Cache every idempotent TMDB read as provider JSON for a versioned canonical
-GET request, rather than caching parsed application models. This prevents a
-parser change, such as adding `tagline`, from treating absent fields in an old
-cached model as authoritative data while preserving reuse across parser-only
-releases.
+Cache every idempotent TMDB read as provider JSON for a versioned,
+HTTPX-serialized GET URL, rather than caching parsed application models. This
+prevents a parser change, such as adding `tagline`, from treating absent fields
+in an old cached model as authoritative data while preserving reuse across
+parser-only releases.
 
 ## Consequences
 
 - Cache only 200 responses and 404 outcomes, using one configured lifetime.
   Other HTTP outcomes and network failures are never cached.
-- Request identity uses method, path, and canonical query parameters. Headers
-  are outside the initial cache contract.
+- Request identity uses the HTTP method and fully serialized URL built by HTTPX
+  before dispatch. Query-parameter ordering remains part of URL identity.
+  Headers are outside the initial cache contract.
 - Change the cache namespace only when provider JSON storage or request
   identity semantics become incompatible. Legacy entries are ignored and
   reclaimed through DiskCache's lazy expiry lifecycle.

--- a/src/sonarr_metadata_rewrite/translator.py
+++ b/src/sonarr_metadata_rewrite/translator.py
@@ -1,8 +1,8 @@
 """TMDB API client with translation caching."""
 
 import time
-from collections.abc import Callable
 from typing import Any, cast
+from urllib.parse import urlencode
 
 import httpx
 from diskcache import Cache  # type: ignore[import-untyped]
@@ -18,6 +18,8 @@ from sonarr_metadata_rewrite.models import (
 
 class Translator:
     """TMDB API client with caching and rate limiting."""
+
+    _RESPONSE_CACHE_NAMESPACE = "tmdb:v3:response:v1"
 
     def __init__(self, settings: Settings, cache: Cache):
         """Initialize client and cache settings."""
@@ -40,17 +42,12 @@ class Translator:
         Returns:
             Dictionary mapping language codes to TranslatedContent objects
         """
-        cache_key = f"translations:{tmdb_ids}"
+        endpoint = f"/{tmdb_ids}/translations"
+        api_data = self._get_cached_json(endpoint)
+        if api_data is None:
+            return {}
 
-        def fetch_translations() -> dict[str, TranslatedContent]:
-            endpoint = f"/{tmdb_ids}/translations"
-            api_data = self._fetch_with_retry(endpoint)
-            return self._parse_api_translations(api_data, tmdb_ids.media_type)
-
-        translations = self._get_with_cache(
-            cache_key, fetch_translations, default_on_404={}
-        )
-        return self._ensure_new_format(translations)
+        return self._parse_api_translations(api_data, tmdb_ids.media_type)
 
     def _fetch_with_retry(
         self, endpoint: str, params: dict[str, Any] | None = None
@@ -98,41 +95,56 @@ class Translator:
                 raise
             return error.response, error
 
-    def _get_with_cache(
-        self,
-        cache_key: str,
-        fetch_func: Callable[[], Any],
-        default_on_404: Any = None,
-    ) -> Any:
-        """Generic cache wrapper that handles 404 caching.
-
-        Args:
-            cache_key: Cache key to use
-            fetch_func: Function that performs the API fetch
-            default_on_404: Value to cache and return on 404 errors
-
-        Returns:
-            Cached or fetched data, or default_on_404 for 404 responses
-        """
-        # Check cache first
-        if cache_key in self.cache:
-            return self.cache[cache_key]
+    def _get_cached_json(
+        self, endpoint: str, params: dict[str, Any] | None = None
+    ) -> dict[str, Any] | None:
+        """Get one TMDB JSON response, caching only 200 and 404 outcomes."""
+        cache_key = self._response_cache_key(endpoint, params)
+        cached_outcome = self.cache.get(cache_key)
+        if cached_outcome is not None:
+            if cached_outcome["status"] == httpx.codes.NOT_FOUND:
+                return None
+            return cast(dict[str, Any], cached_outcome["body"])
 
         try:
-            # Execute the fetch function
-            result = fetch_func()
-            # Cache successful result
-            self.cache.set(cache_key, result, expire=self.cache_expire_seconds)
-            return result
-        except httpx.HTTPStatusError as e:
-            if e.response.status_code == httpx.codes.NOT_FOUND:
-                # Cache 404 with default value
-                self.cache.set(
-                    cache_key, default_on_404, expire=self.cache_expire_seconds
-                )
-                return default_on_404
-            # Re-raise other HTTP errors
-            raise
+            api_data = self._fetch_with_retry(endpoint, params)
+        except httpx.HTTPStatusError as error:
+            if error.response.status_code != httpx.codes.NOT_FOUND:
+                raise
+            self.cache.set(
+                cache_key,
+                {"status": httpx.codes.NOT_FOUND},
+                expire=self.cache_expire_seconds,
+            )
+            return None
+
+        self.cache.set(
+            cache_key,
+            {"status": httpx.codes.OK, "body": api_data},
+            expire=self.cache_expire_seconds,
+        )
+        return api_data
+
+    def _response_cache_key(
+        self, endpoint: str, params: dict[str, Any] | None = None
+    ) -> str:
+        """Build a stable cache key for one TMDB GET request."""
+        query = self._canonical_query_params(params)
+        query_suffix = f"?{query}" if query else ""
+        return f"{self._RESPONSE_CACHE_NAMESPACE}:GET:{endpoint}{query_suffix}"
+
+    @staticmethod
+    def _canonical_query_params(params: dict[str, Any] | None) -> str:
+        """Return canonical URL query parameters for a cache key."""
+        if not params:
+            return ""
+
+        query_items: list[tuple[str, str]] = []
+        for name, value in sorted(params.items()):
+            values = value if isinstance(value, (list, tuple)) else [value]
+            query_items.extend((name, str(item)) for item in values if item is not None)
+
+        return urlencode(query_items)
 
     def _parse_api_translations(
         self, api_data: dict[str, Any], media_type: str
@@ -182,45 +194,39 @@ class Translator:
         Returns:
             Tuple of (original_language, original_title) if found, None otherwise
         """
-        cache_key = f"original_details:{tmdb_ids}"
+        # For episodes, we need both episode name and series original language.
+        if tmdb_ids.media_type == "movie":
+            api_data = self._get_cached_json(f"/movie/{tmdb_ids.tmdb_id}")
+            if api_data is None:
+                return None
+            original_language = api_data.get("original_language", "")
+            original_title = api_data.get("original_title", "")
+        elif tmdb_ids.season is not None and tmdb_ids.episode is not None:
+            episode_endpoint = (
+                f"/tv/{tmdb_ids.tmdb_id}/season/{tmdb_ids.season}"
+                f"/episode/{tmdb_ids.episode}"
+            )
+            episode_data = self._get_cached_json(episode_endpoint)
+            if episode_data is None:
+                return None
 
-        def fetch_details() -> tuple[str, str] | None:
-            # For episodes, we need both episode name and series original language
-            if tmdb_ids.media_type == "movie":
-                api_data = self._fetch_with_retry(f"/movie/{tmdb_ids.tmdb_id}")
-                original_language = api_data.get("original_language", "")
-                original_title = api_data.get("original_title", "")
-            elif tmdb_ids.season is not None and tmdb_ids.episode is not None:
-                # Get episode details for the name
-                episode_endpoint = (
-                    f"/tv/{tmdb_ids.tmdb_id}/season/{tmdb_ids.season}"
-                    f"/episode/{tmdb_ids.episode}"
-                )
-                episode_data = self._fetch_with_retry(episode_endpoint)
+            series_data = self._get_cached_json(f"/tv/{tmdb_ids.tmdb_id}")
+            if series_data is None:
+                return None
 
-                # Get series details for the original language
-                series_endpoint = f"/tv/{tmdb_ids.tmdb_id}"
-                series_data = self._fetch_with_retry(series_endpoint)
+            original_language = series_data.get("original_language", "")
+            original_title = episode_data.get("name", "")
+        else:
+            api_data = self._get_cached_json(f"/tv/{tmdb_ids.tmdb_id}")
+            if api_data is None:
+                return None
+            original_language = api_data.get("original_language", "")
+            original_title = api_data.get("original_name", "")
 
-                original_language = series_data.get("original_language", "")
-                original_title = episode_data.get("name", "")
-            else:
-                # Series details endpoint
-                endpoint = f"/tv/{tmdb_ids.tmdb_id}"
-                api_data = self._fetch_with_retry(endpoint)
+        if original_language and original_title:
+            return (original_language, original_title.strip())
 
-                original_language = api_data.get("original_language", "")
-                original_title = api_data.get("original_name", "")
-
-            if original_language and original_title:
-                return (original_language, original_title.strip())
-
-            return None
-
-        return cast(
-            tuple[str, str] | None,
-            self._get_with_cache(cache_key, fetch_details, default_on_404=None),
-        )
+        return None
 
     def find_tmdb_id_by_external_id(
         self, external_id: str, external_source: str
@@ -234,91 +240,19 @@ class Translator:
         Returns:
             TMDB series ID if found, None otherwise
         """
-        cache_key = f"external_find:{external_source}:{external_id}"
-
-        def fetch_external_id() -> int | None:
-            # Use TMDB's find endpoint with external source
-            endpoint = f"/find/{external_id}"
-            params = {"external_source": external_source}
-
-            api_data = self._fetch_with_retry(endpoint, params)
-
-            # Look for TV results
-            tv_results = api_data.get("tv_results", [])
-            if tv_results:
-                tmdb_id = tv_results[0].get("id")
-                if tmdb_id:
-                    return int(tmdb_id)
-
+        endpoint = f"/find/{external_id}"
+        api_data = self._get_cached_json(endpoint, {"external_source": external_source})
+        if api_data is None:
             return None
 
-        return cast(
-            int | None,
-            self._get_with_cache(cache_key, fetch_external_id, default_on_404=None),
-        )
+        # Look for TV results.
+        tv_results = api_data.get("tv_results", [])
+        if tv_results:
+            tmdb_id = tv_results[0].get("id")
+            if tmdb_id:
+                return int(tmdb_id)
 
-    def _ensure_new_format(
-        self, cached_data: dict[str, TranslatedContent]
-    ) -> dict[str, TranslatedContent]:
-        """Ensure cached data is in new format with TranslatedString objects.
-
-        This handles backward compatibility for cache data from before the
-        model change where TranslatedContent had string fields instead of
-        TranslatedString objects.
-
-        Args:
-            cached_data: Dictionary of cached translation data
-
-        Returns:
-            Dictionary with TranslatedContent objects in new format
-        """
-        converted_data = {}
-
-        for lang_code, content in cached_data.items():
-            has_tagline = hasattr(content, "tagline")
-            tagline = getattr(
-                content,
-                "tagline",
-                TranslatedString(content="", language="unknown"),
-            )
-            if (
-                isinstance(content.title, str)
-                or not has_tagline
-                or not isinstance(tagline, TranslatedString)
-            ):
-                # Old format - convert to new format
-                converted_content = TranslatedContent(
-                    title=(
-                        TranslatedString(
-                            content=content.title,
-                            language=getattr(content, "language", lang_code),
-                        )
-                        if isinstance(content.title, str)
-                        else content.title
-                    ),
-                    description=(
-                        TranslatedString(
-                            content=str(content.description),
-                            language=getattr(content, "language", lang_code),
-                        )
-                        if isinstance(content.description, str)
-                        else content.description
-                    ),
-                    tagline=(
-                        tagline
-                        if isinstance(tagline, TranslatedString)
-                        else TranslatedString(
-                            content=str(tagline),
-                            language=getattr(content, "language", lang_code),
-                        )
-                    ),
-                )
-                converted_data[lang_code] = converted_content
-            else:
-                # Already in new format
-                converted_data[lang_code] = content
-
-        return converted_data
+        return None
 
     def select_best_image(
         self,
@@ -346,14 +280,9 @@ class Translator:
         # Fetch images from TMDB
         # NOTE: Do NOT pass include_image_language due to TMDB API bug;
         # fetch all images and filter locally in Python.
-        # Cache by endpoint only since server response is independent of
-        # preference ordering; selection happens client-side.
-        cache_key = f"images:{endpoint}"
-
-        def fetch_images() -> dict[str, Any]:
-            return self._fetch_with_retry(endpoint)
-
-        api_data = self._get_with_cache(cache_key, fetch_images, default_on_404={})
+        api_data = self._get_cached_json(endpoint)
+        if api_data is None:
+            return None
 
         # Select from appropriate array
         if kind == "poster":

--- a/src/sonarr_metadata_rewrite/translator.py
+++ b/src/sonarr_metadata_rewrite/translator.py
@@ -2,7 +2,6 @@
 
 import time
 from typing import Any, cast
-from urllib.parse import urlencode
 
 import httpx
 from diskcache import Cache  # type: ignore[import-untyped]
@@ -19,7 +18,7 @@ from sonarr_metadata_rewrite.models import (
 class Translator:
     """TMDB API client with caching and rate limiting."""
 
-    _RESPONSE_CACHE_NAMESPACE = "tmdb:v3:response:v1"
+    _RESPONSE_CACHE_NAMESPACE = "tmdb:v3:response:v2"
 
     def __init__(self, settings: Settings, cache: Cache):
         """Initialize client and cache settings."""
@@ -128,23 +127,9 @@ class Translator:
     def _response_cache_key(
         self, endpoint: str, params: dict[str, Any] | None = None
     ) -> str:
-        """Build a stable cache key for one TMDB GET request."""
-        query = self._canonical_query_params(params)
-        query_suffix = f"?{query}" if query else ""
-        return f"{self._RESPONSE_CACHE_NAMESPACE}:GET:{endpoint}{query_suffix}"
-
-    @staticmethod
-    def _canonical_query_params(params: dict[str, Any] | None) -> str:
-        """Return canonical URL query parameters for a cache key."""
-        if not params:
-            return ""
-
-        query_items: list[tuple[str, str]] = []
-        for name, value in sorted(params.items()):
-            values = value if isinstance(value, (list, tuple)) else [value]
-            query_items.extend((name, str(item)) for item in values if item is not None)
-
-        return urlencode(query_items)
+        """Build a cache key from HTTPX's serialized GET request URL."""
+        request = self.client.build_request("GET", endpoint, params=params)
+        return f"{self._RESPONSE_CACHE_NAMESPACE}:{request.method}:{request.url}"
 
     def _parse_api_translations(
         self, api_data: dict[str, Any], media_type: str

--- a/tests/unit/test_translator.py
+++ b/tests/unit/test_translator.py
@@ -4,7 +4,7 @@ import json
 from collections.abc import Generator
 from types import SimpleNamespace
 from typing import Any
-from unittest.mock import Mock, patch
+from unittest.mock import Mock, call, patch
 
 import httpx
 import pytest
@@ -1035,6 +1035,51 @@ def test_get_original_details_404_cached(
 
     # Results should be identical
     assert details1 == details2
+
+
+@pytest.mark.parametrize(
+    ("tmdb_ids", "endpoint"),
+    [
+        (TmdbIds(tmdb_id=99999, media_type="movie"), "/movie/99999"),
+        (
+            TmdbIds(tmdb_id=99999, media_type="tv", season=1, episode=1),
+            "/tv/99999/season/1/episode/1",
+        ),
+    ],
+)
+@patch("httpx.Client.get")
+def test_get_original_details_returns_none_when_resource_not_found(
+    mock_get: Mock,
+    translator: Translator,
+    tmdb_ids: TmdbIds,
+    endpoint: str,
+) -> None:
+    """Test movie and episode detail 404 responses return None."""
+    mock_get.side_effect = mock_not_found_error()
+
+    assert translator.get_original_details(tmdb_ids) is None
+    mock_get.assert_called_once_with(endpoint, params=None)
+
+
+@patch("httpx.Client.get")
+def test_get_original_details_episode_returns_none_when_series_not_found(
+    mock_get: Mock,
+    translator: Translator,
+    mock_episode_details_response: dict[str, Any],
+) -> None:
+    """Test episode details return None when its series is unavailable."""
+    episode_response = Mock()
+    episode_response.raise_for_status.return_value = None
+    episode_response.json.return_value = mock_episode_details_response
+    mock_get.side_effect = [episode_response, mock_not_found_error()]
+
+    tmdb_ids = TmdbIds(tmdb_id=99999, media_type="tv", season=1, episode=1)
+
+    assert translator.get_original_details(tmdb_ids) is None
+    assert mock_get.call_args_list == [
+        call("/tv/99999/season/1/episode/1", params=None),
+        call("/tv/99999", params=None),
+    ]
 
 
 @patch("httpx.Client.get")

--- a/tests/unit/test_translator.py
+++ b/tests/unit/test_translator.py
@@ -387,19 +387,23 @@ def test_get_translations_skips_entry_without_language_code(
     assert "en-US" in translations
 
 
-def test_response_cache_key_canonicalizes_query_params(translator: Translator) -> None:
-    """Test equivalent query parameters generate the same response-cache key."""
-    first_key = translator._response_cache_key(
-        "/find/tt0286112",
-        {"z": "2", "a": "1", "ignored": None},
-    )
-    second_key = translator._response_cache_key(
-        "/find/tt0286112",
-        {"ignored": None, "a": "1", "z": "2"},
-    )
+def test_response_cache_key_uses_httpx_serialized_url(translator: Translator) -> None:
+    """Test cache keys use the same URL serialization as HTTPX requests."""
+    endpoint = "/find/tt0286112"
+    params = {"empty": None, "enabled": True, "query": "A+B"}
+    request = translator.client.build_request("GET", endpoint, params=params)
 
-    assert first_key == second_key
-    assert first_key == ("tmdb:v3:response:v1:GET:/find/tt0286112?a=1&z=2")
+    cache_key = translator._response_cache_key(endpoint, params)
+
+    assert cache_key == (
+        f"{translator._RESPONSE_CACHE_NAMESPACE}:{request.method}:{request.url}"
+    )
+    assert translator._response_cache_key(endpoint, {"empty": None}) != (
+        translator._response_cache_key(endpoint)
+    )
+    assert translator._response_cache_key(endpoint, {"enabled": True}) != (
+        translator._response_cache_key(endpoint, {"enabled": "True"})
+    )
 
 
 @patch("httpx.Client.get")

--- a/tests/unit/test_translator.py
+++ b/tests/unit/test_translator.py
@@ -11,7 +11,7 @@ import pytest
 from diskcache import Cache  # type: ignore[import-untyped]
 
 from sonarr_metadata_rewrite.config import Settings
-from sonarr_metadata_rewrite.models import TmdbIds, TranslatedContent, TranslatedString
+from sonarr_metadata_rewrite.models import TmdbIds, TranslatedString
 from sonarr_metadata_rewrite.translator import Translator
 
 
@@ -387,24 +387,19 @@ def test_get_translations_skips_entry_without_language_code(
     assert "en-US" in translations
 
 
-def test_cache_functionality(
-    translator: Translator, mock_series_response: dict[str, Any]
-) -> None:
-    """Test DiskCache functionality."""
-    tmdb_ids = TmdbIds(tmdb_id=12345, media_type="tv")
-    cache_key = f"translations:{tmdb_ids}/translations"
+def test_response_cache_key_canonicalizes_query_params(translator: Translator) -> None:
+    """Test equivalent query parameters generate the same response-cache key."""
+    first_key = translator._response_cache_key(
+        "/find/tt0286112",
+        {"z": "2", "a": "1", "ignored": None},
+    )
+    second_key = translator._response_cache_key(
+        "/find/tt0286112",
+        {"ignored": None, "a": "1", "z": "2"},
+    )
 
-    # Verify cache starts empty
-    assert cache_key not in translator.cache
-
-    # Add item to cache
-    translations = {"en-US": mock_series_response}
-    translator.cache.set(cache_key, translations, expire=3600)
-
-    # Verify cache contains the item
-    assert cache_key in translator.cache
-    cached_data = translator.cache[cache_key]
-    assert cached_data == translations
+    assert first_key == second_key
+    assert first_key == ("tmdb:v3:response:v1:GET:/find/tt0286112?a=1&z=2")
 
 
 @patch("httpx.Client.get")
@@ -424,6 +419,11 @@ def test_caching_integration(
     translations1 = translator.get_translations(tmdb_ids)
     assert mock_get.call_count == 1
     assert len(translations1) == 3
+    cache_key = translator._response_cache_key("/tv/12345/translations")
+    assert translator.cache[cache_key] == {
+        "status": 200,
+        "body": mock_series_response,
+    }
 
     # Second call should use cache (no additional API calls)
     translations2 = translator.get_translations(tmdb_ids)
@@ -664,27 +664,24 @@ def test_rate_limit_max_retries_exceeded(
     assert actual_delays == expected_delays
 
 
+@pytest.mark.parametrize("status_code", [400, 401, 403, 500])
 @patch("httpx.Client.get")
-def test_non_rate_limit_http_error_no_retry(
-    mock_get: Mock, translator: Translator
+def test_non_cacheable_http_error_is_not_retried_or_cached(
+    mock_get: Mock, translator: Translator, status_code: int
 ) -> None:
-    """Test that non-rate-limit HTTP errors are not retried."""
-    # Return 500 error (not rate limit)
-    server_error_response = Mock()
-    server_error_response.status_code = 500
-    server_error = httpx.HTTPStatusError(
-        "Internal Server Error", request=Mock(), response=server_error_response
+    """Test non-404 HTTP errors are neither retried nor cached."""
+    error_response = Mock(status_code=status_code)
+    error = httpx.HTTPStatusError(
+        f"HTTP {status_code}", request=Mock(), response=error_response
     )
-    mock_get.side_effect = server_error
+    mock_get.side_effect = error
 
-    tmdb_ids = TmdbIds(tmdb_id=12345, media_type="tv")
+    with pytest.raises(httpx.HTTPStatusError, match=f"HTTP {status_code}"):
+        translator.get_translations(TmdbIds(tmdb_id=12345, media_type="tv"))
 
-    # Should raise the error immediately without retries
-    with pytest.raises(httpx.HTTPStatusError, match="Internal Server Error"):
-        translator.get_translations(tmdb_ids)
-
-    # Should have made only 1 attempt (no retries)
     assert mock_get.call_count == 1
+    cache_key = translator._response_cache_key("/tv/12345/translations")
+    assert cache_key not in translator.cache
 
 
 @patch("httpx.Client.get")
@@ -737,7 +734,7 @@ def test_rate_limit_preserves_cache_on_failure(
     mock_get.side_effect = rate_limit_error
 
     tmdb_ids = TmdbIds(tmdb_id=12345, media_type="tv")
-    cache_key = f"translations:{tmdb_ids}"
+    cache_key = translator._response_cache_key("/tv/12345/translations")
 
     # Ensure cache is empty initially
     assert cache_key not in translator.cache
@@ -925,151 +922,52 @@ def test_find_tmdb_id_by_external_id_cache_negative_result(
         mock_get.assert_called_once()
 
 
-def test_ensure_new_format_backward_compatibility(translator: Translator) -> None:
-    """Test backward compatibility with old cached TranslatedContent format."""
-    # Create mock old format TranslatedContent objects (pre-model change)
-    # These simulate cached data with string fields instead of TranslatedString objects
-    old_format_content_1 = SimpleNamespace(
-        title="旧格式标题",  # str instead of TranslatedString
-        description="旧格式描述",  # str instead of TranslatedString
-        language="zh-CN",  # old format had language field
-    )
-
-    old_format_content_2 = SimpleNamespace(
-        title="Old Format Title", description="Old format description", language="en-US"
-    )
-
-    # Create new format TranslatedContent for mixed testing
-    new_format_content = TranslatedContent(
-        title=TranslatedString(content="新格式标题", language="ja"),
-        description=TranslatedString(content="新格式描述", language="ja"),
-    )
-
-    # Create cached data with mix of old and new formats
-    cached_data = {
-        "zh-CN": old_format_content_1,
-        "en-US": old_format_content_2,
-        "ja": new_format_content,
-    }
-
-    # Test the conversion method
-    converted_data = translator._ensure_new_format(cached_data)  # type: ignore[arg-type]
-
-    # Verify all data is now in new format
-    assert len(converted_data) == 3
-
-    # Check converted old format data
-    zh_cn = converted_data["zh-CN"]
-    assert isinstance(zh_cn, TranslatedContent)
-    assert isinstance(zh_cn.title, TranslatedString)
-    assert isinstance(zh_cn.description, TranslatedString)
-    assert zh_cn.title.content == "旧格式标题"
-    assert zh_cn.title.language == "zh-CN"
-    assert zh_cn.description.content == "旧格式描述"
-    assert zh_cn.description.language == "zh-CN"
-    assert zh_cn.tagline.content == ""
-    assert zh_cn.tagline.language == "unknown"
-
-    en_us = converted_data["en-US"]
-    assert isinstance(en_us, TranslatedContent)
-    assert isinstance(en_us.title, TranslatedString)
-    assert isinstance(en_us.description, TranslatedString)
-    assert en_us.title.content == "Old Format Title"
-    assert en_us.title.language == "en-US"
-    assert en_us.description.content == "Old format description"
-    assert en_us.description.language == "en-US"
-
-    # Check that already new format data is preserved unchanged
-    ja = converted_data["ja"]
-    assert isinstance(ja, TranslatedContent)
-    assert isinstance(ja.title, TranslatedString)
-    assert isinstance(ja.description, TranslatedString)
-    assert ja.title.content == "新格式标题"
-    assert ja.title.language == "ja"
-    assert ja.description.content == "新格式描述"
-    assert ja.description.language == "ja"
-
-
-def test_ensure_new_format_adds_tagline_to_current_cached_format(
-    translator: Translator,
+@patch("httpx.Client.get")
+def test_get_translations_ignores_legacy_derived_cache(
+    mock_get: Mock, translator: Translator, mock_series_response: dict[str, Any]
 ) -> None:
-    """Test cached content without tagline gains its default value."""
-    cached_data = {
-        "zh-CN": SimpleNamespace(
-            title=TranslatedString(content="中文标题", language="zh-CN"),
-            description=TranslatedString(content="中文描述", language="zh-CN"),
-        )
-    }
-
-    converted_data = translator._ensure_new_format(cached_data)  # type: ignore[arg-type]
-
-    assert converted_data["zh-CN"].title.content == "中文标题"
-    assert converted_data["zh-CN"].description.content == "中文描述"
-    assert converted_data["zh-CN"].tagline == TranslatedString(
-        content="", language="unknown"
-    )
-
-
-def test_get_translations_cache_backward_compatibility_integration(
-    translator: Translator,
-) -> None:
-    """Test cache backward compatibility in real get_translations workflow."""
-    # Create old format cached data
-    old_cached_content = SimpleNamespace(
-        title="缓存的旧标题", description="缓存的旧描述", language="zh-CN"
-    )
-
-    # Manually set old format data in cache to simulate pre-upgrade cache
+    """Test a legacy parsed cache entry cannot hide new TMDB fields."""
     tmdb_ids = TmdbIds(tmdb_id=12345, media_type="tv")
-    cache_key = f"translations:{tmdb_ids}"
-    translator.cache.set(cache_key, {"zh-CN": old_cached_content})
+    legacy_cache_key = f"translations:{tmdb_ids}"
+    translator.cache.set(
+        legacy_cache_key,
+        {
+            "zh-CN": SimpleNamespace(
+                title=TranslatedString(content="旧中文标题", language="zh-CN"),
+                description=TranslatedString(content="旧中文描述", language="zh-CN"),
+            )
+        },
+    )
+    mock_response = Mock()
+    mock_response.raise_for_status.return_value = None
+    mock_response.json.return_value = mock_series_response
+    mock_get.return_value = mock_response
 
-    # Call get_translations - should convert old format to new format
     translations = translator.get_translations(tmdb_ids)
 
-    # Verify the cached data was converted properly
-    assert len(translations) == 1
-    assert "zh-CN" in translations
-
+    assert mock_get.call_count == 1
     zh_cn = translations["zh-CN"]
-    assert isinstance(zh_cn, TranslatedContent)
-    assert isinstance(zh_cn.title, TranslatedString)
-    assert isinstance(zh_cn.description, TranslatedString)
-    assert zh_cn.title.content == "缓存的旧标题"
-    assert zh_cn.title.language == "zh-CN"
-    assert zh_cn.description.content == "缓存的旧描述"
-    assert zh_cn.description.language == "zh-CN"
+    assert zh_cn.tagline.content == "命运由你掌握。"
+    response_cache_key = translator._response_cache_key("/tv/12345/translations")
+    assert translator.cache[response_cache_key]["body"] == mock_series_response
 
 
 @patch("httpx.Client.get")
-def test_get_with_cache_404_caching(mock_get: Mock, translator: Translator) -> None:
-    """Test that _get_with_cache properly caches 404 responses."""
-    # Mock 404 HTTP error
+def test_get_cached_json_caches_404_outcome(
+    mock_get: Mock, translator: Translator
+) -> None:
+    """Test the response cache stores a not-found outcome."""
     mock_get.side_effect = mock_not_found_error()
+    endpoint = "/test/endpoint"
+    cache_key = translator._response_cache_key(endpoint)
 
-    # Define a simple fetch function that calls _fetch_with_retry
-    def fetch_func() -> dict[str, Any]:
-        return translator._fetch_with_retry("/test/endpoint")
-
-    cache_key = "test_404_cache"
-    default_value = {"test": "default"}
-
-    # First call should hit API and cache the default value
-    result1 = translator._get_with_cache(cache_key, fetch_func, default_value)
-    assert result1 == default_value
+    assert translator._get_cached_json(endpoint) is None
     assert mock_get.call_count == 1
-
-    # Verify the default value was cached
     assert cache_key in translator.cache
-    assert translator.cache[cache_key] == default_value
+    assert translator.cache[cache_key] == {"status": 404}
 
-    # Second call should use cache (no additional API calls)
-    result2 = translator._get_with_cache(cache_key, fetch_func, default_value)
-    assert result2 == default_value
-    assert mock_get.call_count == 1  # Still only 1 call
-
-    # Results should be identical
-    assert result1 == result2
+    assert translator._get_cached_json(endpoint) is None
+    assert mock_get.call_count == 1
 
 
 @patch("httpx.Client.get")
@@ -1079,7 +977,7 @@ def test_get_translations_404_cached(mock_get: Mock, translator: Translator) -> 
     mock_get.side_effect = mock_not_found_error()
 
     tmdb_ids = TmdbIds(tmdb_id=99999, media_type="tv")  # Non-existent series
-    cache_key = f"translations:{tmdb_ids}"
+    cache_key = translator._response_cache_key("/tv/99999/translations")
 
     # Verify cache starts empty
     assert cache_key not in translator.cache
@@ -1089,9 +987,9 @@ def test_get_translations_404_cached(mock_get: Mock, translator: Translator) -> 
     assert translations1 == {}
     assert mock_get.call_count == 1
 
-    # Verify empty dict was cached
+    # Verify the not-found outcome was cached
     assert cache_key in translator.cache
-    assert translator.cache[cache_key] == {}
+    assert translator.cache[cache_key] == {"status": 404}
 
     # Second call should use cache (no additional API calls)
     translations2 = translator.get_translations(tmdb_ids)
@@ -1116,7 +1014,7 @@ def test_get_original_details_404_cached(
     mock_get.side_effect = not_found_error
 
     tmdb_ids = TmdbIds(tmdb_id=99999, media_type="tv")  # Non-existent series
-    cache_key = f"original_details:{tmdb_ids}"
+    cache_key = translator._response_cache_key("/tv/99999")
 
     # Verify cache starts empty
     assert cache_key not in translator.cache
@@ -1126,9 +1024,9 @@ def test_get_original_details_404_cached(
     assert details1 is None
     assert mock_get.call_count == 1
 
-    # Verify None was cached
+    # Verify the not-found outcome was cached
     assert cache_key in translator.cache
-    assert translator.cache[cache_key] is None
+    assert translator.cache[cache_key] == {"status": 404}
 
     # Second call should use cache (no additional API calls)
     details2 = translator.get_original_details(tmdb_ids)
@@ -1152,7 +1050,9 @@ def test_find_tmdb_id_404_cached(mock_get: Mock, translator: Translator) -> None
 
     external_id = "99999"
     external_source = "tvdb_id"
-    cache_key = f"external_find:{external_source}:{external_id}"
+    cache_key = translator._response_cache_key(
+        "/find/99999", {"external_source": "tvdb_id"}
+    )
 
     # Verify cache starts empty
     assert cache_key not in translator.cache
@@ -1162,9 +1062,9 @@ def test_find_tmdb_id_404_cached(mock_get: Mock, translator: Translator) -> None
     assert result1 is None
     assert mock_get.call_count == 1
 
-    # Verify None was cached
+    # Verify the not-found outcome was cached
     assert cache_key in translator.cache
-    assert translator.cache[cache_key] is None
+    assert translator.cache[cache_key] == {"status": 404}
 
     # Second call should use cache (no additional API calls)
     result2 = translator.find_tmdb_id_by_external_id(external_id, external_source)


### PR DESCRIPTION
## Problem

Recent tagline support cannot recover translated taglines for installations with pre-existing cache entries. Previous releases cached parsed `TranslatedContent` objects. Entries written before `tagline` existed contain no provider value, and compatibility handling supplies an empty tagline. Cache remains authoritative until expiry even when TMDB has translated tagline data.

## Change

Store versioned TMDB GET response JSON keyed by the HTTPX-serialized request URL instead of parsed application models. Parser changes now read provider fields from raw cached responses, while incompatible legacy derived-cache entries are ignored. The v2 cache identity uses the GET method and HTTPX's fully serialized URL before dispatch, avoiding separate query serialization. Only successful response bodies and explicit not-found outcomes are retained; HTTP and network failures are not cached.

This applies consistently to translation, details, image, and external-ID TMDB reads.

## Validation

- `./scripts/run-unit-tests.sh` (`329 passed`)
- `./scripts/lint.sh --check`
- `npx jscpd`