### PR TITLE
fix: handle episodes before parent NFO exists

### DIFF
--- a/src/sonarr_metadata_rewrite/translator.py
+++ b/src/sonarr_metadata_rewrite/translator.py
@@ -237,6 +237,12 @@ class Translator:
             if tmdb_id:
                 return int(tmdb_id)
 
+        tv_episode_results = api_data.get("tv_episode_results", [])
+        if tv_episode_results:
+            show_id = tv_episode_results[0].get("show_id")
+            if show_id:
+                return int(show_id)
+
         return None
 
     def select_best_image(

--- a/tests/integration/test_sonarr_integration.py
+++ b/tests/integration/test_sonarr_integration.py
@@ -10,6 +10,7 @@ from tests.integration.test_helpers import (
     SeriesWithNfos,
     ServiceRunner,
     create_fake_multi_episode_file,
+    parse_nfo_content,
     verify_images,
     verify_translations,
     wait_for_nfo_files,
@@ -51,6 +52,8 @@ EVERY_TREASURE_TELLS_A_STORY_TVDB_ID = 364698
 EVERY_TREASURE_TELLS_A_STORY_IMAGES = [
     "poster.jpg",
 ]  # Sonarr only generates series poster image
+CAPE_FEAR_TVDB_ID = 456813
+CAPE_FEAR_EPISODE_TVDB_ID = 11593814
 GEN_V_TVDB_ID = 417909
 GEN_V_IMAGES = [
     "poster.jpg",
@@ -267,6 +270,52 @@ def test_advanced_translation_scenarios(
             possible_languages=list(possible_languages),
             require_tagline=require_tagline,
         )
+
+
+@pytest.mark.integration
+@pytest.mark.slow
+def test_episode_tvdb_external_id_lookup(
+    temp_sonarr_media_root: Path,
+    configured_sonarr_container: SonarrClient,
+) -> None:
+    """Translate a Sonarr episode NFO with only an episode TVDB ID (issue #105)."""
+    with SeriesWithNfos(
+        configured_sonarr_container,
+        temp_sonarr_media_root,
+        CAPE_FEAR_TVDB_ID,
+        [],
+        episodes=[("Episode 8", 1, 8)],
+    ) as (nfo_files, _):
+        nfo_metadata = {nfo_path: parse_nfo_content(nfo_path) for nfo_path in nfo_files}
+        parent_nfos = [
+            nfo_path
+            for nfo_path in nfo_files
+            if nfo_metadata[nfo_path]["root_tag"] == "tvshow"
+        ]
+        assert len(parent_nfos) == 1
+        episode_nfos = [
+            nfo_path
+            for nfo_path in nfo_files
+            if nfo_metadata[nfo_path]["tvdb_id"] == CAPE_FEAR_EPISODE_TVDB_ID
+        ]
+        assert len(episode_nfos) == 1
+        assert nfo_metadata[episode_nfos[0]]["tmdb_id"] is None
+        parent_nfos[0].unlink()
+
+        with ServiceRunner(
+            temp_sonarr_media_root,
+            {
+                "ENABLE_FILE_MONITOR": "false",
+                "ENABLE_IMAGE_REWRITE": "false",
+                "PREFERRED_LANGUAGES": "fr-FR",
+            },
+        ):
+            verify_translations(
+                episode_nfos,
+                expected_language="fr",
+                possible_languages=["en", "fr"],
+                require_tagline=False,
+            )
 
 
 @pytest.mark.integration

--- a/tests/integration/test_sonarr_integration.py
+++ b/tests/integration/test_sonarr_integration.py
@@ -300,6 +300,7 @@ def test_episode_tvdb_external_id_lookup(
         ]
         assert len(episode_nfos) == 1
         assert nfo_metadata[episode_nfos[0]]["tmdb_id"] is None
+        # Simulate Sonarr writing tvshow.nfo after the episode NFO is processed.
         parent_nfos[0].unlink()
 
         with ServiceRunner(

--- a/tests/unit/test_translator.py
+++ b/tests/unit/test_translator.py
@@ -814,6 +814,39 @@ def test_find_tmdb_id_by_external_id_tvdb_success(
         )
 
 
+def test_find_tmdb_id_by_external_id_tvdb_episode_success(
+    translator: Translator,
+) -> None:
+    """Resolve an episode TVDB ID through its parent TMDB show ID."""
+    episode_response: dict[str, Any] = {
+        "movie_results": [],
+        "person_results": [],
+        "tv_results": [],
+        "tv_episode_results": [
+            {
+                "id": 5454819,
+                "season_number": 1,
+                "episode_number": 8,
+                "show_id": 277439,
+            }
+        ],
+        "tv_season_results": [],
+    }
+
+    with patch.object(translator.client, "get") as mock_get:
+        mock_response = Mock()
+        mock_response.raise_for_status.return_value = None
+        mock_response.json.return_value = episode_response
+        mock_get.return_value = mock_response
+
+        result = translator.find_tmdb_id_by_external_id("11593814", "tvdb_id")
+
+        assert result == 277439
+        mock_get.assert_called_once_with(
+            "/find/11593814", params={"external_source": "tvdb_id"}
+        )
+
+
 def test_find_tmdb_id_by_external_id_imdb_success(
     translator: Translator, mock_find_imdb_response: dict[str, Any]
 ) -> None:


### PR DESCRIPTION
## Root Cause

Sonarr can close an episode NFO before it writes the series-level `tvshow.nfo`. File monitoring processes that close event immediately. At that point, parent-NFO lookup cannot find a series TMDB ID.

The episode NFO contains only an episode-level TVDB ID. TMDB maps that ID through `/find/{tvdb_id}` in `tv_episode_results`, where parent series ID is `show_id`, not `tv_results`. The resolver only read `tv_results`, so it logged `No TMDB ID found in .nfo file`.

When `tvshow.nfo` appears later, its event processes only that file. The already-failed episode is not retried until a later periodic scan.

## Change

Keep `tv_results` as first choice. If it is empty, resolve series ID from `tv_episode_results[0].show_id`. Episode translation can then continue without waiting for parent `tvshow.nfo`.

## Reproduction

Confirmed against `kfstorm/sonarr-metadata-rewrite:latest` with Cape Fear NFOs from #105:

- Scanner succeeds when both NFO files already exist.
- File monitor succeeds when `tvshow.nfo` arrives first.
- File monitor logs the reported warning when episode NFO arrives first; writing `tvshow.nfo` later does not retry that episode.

## Regression Coverage

- Unit test: TMDB `/find` response with only `tv_episode_results` resolves `show_id`.
- Real Sonarr integration: Sonarr generates Cape Fear S01E08 NFO with TVDB episode ID `11593814`. Test removes parent `tvshow.nfo` to simulate it appearing after episode processing, then confirms translation through real TMDB.

## Verification

- `uv run pytest tests/unit`
- `uv run pytest tests/integration/test_sonarr_integration.py::test_episode_tvdb_external_id_lookup -m integration --tb=short`
- `./scripts/lint.sh --check`
- `npx jscpd src/sonarr_metadata_rewrite/translator.py tests/unit/test_translator.py tests/integration/test_sonarr_integration.py`

Closes #105