### PR TITLE
fix: select TMDB result by resource type

### DIFF
--- a/src/sonarr_metadata_rewrite/metadata_processor.py
+++ b/src/sonarr_metadata_rewrite/metadata_processor.py
@@ -3,6 +3,7 @@
 import logging
 import xml.etree.ElementTree as ET
 from pathlib import Path
+from typing import Literal
 
 from sonarr_metadata_rewrite.backup_utils import create_backup, get_backup_path
 from sonarr_metadata_rewrite.config import Settings
@@ -427,10 +428,14 @@ class MetadataProcessor:
         Returns:
             TMDB series ID if found, None otherwise
         """
+        resource_type: Literal["series", "episode"] = (
+            "episode" if info.file_type == "episodedetails" else "series"
+        )
+
         # Try TVDB ID first
         if info.tvdb_id:
             tmdb_id = self.translator.find_tmdb_id_by_external_id(
-                str(info.tvdb_id), "tvdb_id"
+                str(info.tvdb_id), "tvdb_id", resource_type=resource_type
             )
             if tmdb_id:
                 return tmdb_id
@@ -438,7 +443,7 @@ class MetadataProcessor:
         # Try IMDB ID
         if info.imdb_id:
             tmdb_id = self.translator.find_tmdb_id_by_external_id(
-                info.imdb_id, "imdb_id"
+                info.imdb_id, "imdb_id", resource_type=resource_type
             )
             if tmdb_id:
                 return tmdb_id

--- a/src/sonarr_metadata_rewrite/translator.py
+++ b/src/sonarr_metadata_rewrite/translator.py
@@ -1,7 +1,7 @@
 """TMDB API client with translation caching."""
 
 import time
-from typing import Any, cast
+from typing import Any, Literal, cast
 
 import httpx
 from diskcache import Cache  # type: ignore[import-untyped]
@@ -214,13 +214,18 @@ class Translator:
         return None
 
     def find_tmdb_id_by_external_id(
-        self, external_id: str, external_source: str
+        self,
+        external_id: str,
+        external_source: str,
+        *,
+        resource_type: Literal["series", "episode"] = "series",
     ) -> int | None:
         """Find TMDB ID using external ID (TVDB or IMDB).
 
         Args:
             external_id: The external ID (e.g., TVDB or IMDB ID)
             external_source: Source type ('tvdb_id' or 'imdb_id')
+            resource_type: Resource type being resolved.
 
         Returns:
             TMDB series ID if found, None otherwise
@@ -230,18 +235,19 @@ class Translator:
         if api_data is None:
             return None
 
-        # Look for TV results.
-        tv_results = api_data.get("tv_results", [])
-        if tv_results:
-            tmdb_id = tv_results[0].get("id")
-            if tmdb_id:
-                return int(tmdb_id)
-
-        tv_episode_results = api_data.get("tv_episode_results", [])
-        if tv_episode_results:
-            show_id = tv_episode_results[0].get("show_id")
-            if show_id:
-                return int(show_id)
+        if resource_type == "episode":
+            results = api_data.get("tv_episode_results", [])
+        else:
+            results = api_data.get("tv_results", [])
+        if results:
+            result = results[0]
+            result_id = (
+                result.get("show_id")
+                if resource_type == "episode"
+                else result.get("id")
+            )
+            if result_id:
+                return int(result_id)
 
         return None
 

--- a/tests/integration/test_translator_integration.py
+++ b/tests/integration/test_translator_integration.py
@@ -1,0 +1,68 @@
+"""Integration tests against the live TMDB API."""
+
+from pathlib import Path
+
+import pytest
+from diskcache import Cache  # type: ignore[import-untyped]
+
+from sonarr_metadata_rewrite.config import Settings
+from sonarr_metadata_rewrite.models import TmdbIds
+from sonarr_metadata_rewrite.translator import Translator
+
+BERSERK_TMDB_ID = 35935
+BERSERK_EPISODE_6_TVDB_ID = 127401
+BERSERK_EPISODE_16_TVDB_ID = 127411
+
+
+@pytest.mark.integration
+@pytest.mark.slow
+def test_berserk_episode_tvdb_lookup_and_french_translations(
+    tmp_path: Path,
+) -> None:
+    """Reproduce both Berserk lookup failures reported after v1.2.3."""
+    settings = Settings(
+        cache_dir=tmp_path / "cache",
+        rewrite_root_dirs=[tmp_path],
+        preferred_languages=["fr-FR"],
+    )
+    cache = Cache(str(settings.cache_dir))
+    translator = Translator(settings, cache)
+
+    try:
+        resolved_ids = {
+            episode_tvdb_id: translator.find_tmdb_id_by_external_id(
+                str(episode_tvdb_id),
+                "tvdb_id",
+                resource_type="episode",
+            )
+            for episode_tvdb_id in (
+                BERSERK_EPISODE_6_TVDB_ID,
+                BERSERK_EPISODE_16_TVDB_ID,
+            )
+        }
+        episode_6 = translator.get_translations(
+            TmdbIds(
+                tmdb_id=BERSERK_TMDB_ID,
+                media_type="tv",
+                season=1,
+                episode=6,
+            )
+        )
+        episode_16 = translator.get_translations(
+            TmdbIds(
+                tmdb_id=BERSERK_TMDB_ID,
+                media_type="tv",
+                season=1,
+                episode=16,
+            )
+        )
+
+        assert episode_6["fr-FR"].title.content == "Zodd l'immortel"
+        assert episode_16["fr-FR"].title.content == "Le conquérant"
+        assert resolved_ids == {
+            BERSERK_EPISODE_6_TVDB_ID: BERSERK_TMDB_ID,
+            BERSERK_EPISODE_16_TVDB_ID: BERSERK_TMDB_ID,
+        }
+    finally:
+        translator.client.close()
+        cache.close()

--- a/tests/unit/test_metadata_processor.py
+++ b/tests/unit/test_metadata_processor.py
@@ -1354,7 +1354,7 @@ def test_process_file_tvdb_id_only_success(
 
     # Verify external ID lookup was called with correct parameters
     processor.translator.find_tmdb_id_by_external_id.assert_called_with(
-        "123456", "tvdb_id"
+        "123456", "tvdb_id", resource_type="series"
     )
 
 
@@ -1388,7 +1388,7 @@ def test_process_file_imdb_id_only_success(
 
     # Verify external ID lookup was called with correct IMDB ID
     mock_translator.find_tmdb_id_by_external_id.assert_called_with(
-        "tt1234567", "imdb_id"
+        "tt1234567", "imdb_id", resource_type="series"
     )
 
 
@@ -1441,7 +1441,9 @@ def test_process_file_episode_inherits_parent_tvdb_id(
     )
 
     # Verify external ID lookup was called for parent's TVDB ID
-    mock_translator.find_tmdb_id_by_external_id.assert_called_with("123456", "tvdb_id")
+    mock_translator.find_tmdb_id_by_external_id.assert_called_with(
+        "123456", "tvdb_id", resource_type="series"
+    )
 
 
 def test_process_file_external_id_lookup_fails(
@@ -1558,7 +1560,9 @@ def test_process_file_episode_external_id_priority_over_parent_external_id(
 
     # Verify external ID lookup was called for episode's TVDB ID (4499792)
     # Should NOT be called for parent's IDs since episode has its own
-    mock_translator.find_tmdb_id_by_external_id.assert_called_with("4499792", "tvdb_id")
+    mock_translator.find_tmdb_id_by_external_id.assert_called_with(
+        "4499792", "tvdb_id", resource_type="episode"
+    )
 
 
 def test_content_matches_after_fallback_skips_processing(

--- a/tests/unit/test_translator.py
+++ b/tests/unit/test_translator.py
@@ -839,12 +839,61 @@ def test_find_tmdb_id_by_external_id_tvdb_episode_success(
         mock_response.json.return_value = episode_response
         mock_get.return_value = mock_response
 
-        result = translator.find_tmdb_id_by_external_id("11593814", "tvdb_id")
+        result = translator.find_tmdb_id_by_external_id(
+            "11593814", "tvdb_id", resource_type="episode"
+        )
 
         assert result == 277439
         mock_get.assert_called_once_with(
             "/find/11593814", params={"external_source": "tvdb_id"}
         )
+
+
+@pytest.fixture
+def mock_find_tvdb_collision_response() -> dict[str, Any]:
+    """Mock TMDB response containing colliding series and episode results."""
+    return {
+        "movie_results": [],
+        "person_results": [],
+        "tv_results": [{"id": 23747}],
+        "tv_episode_results": [{"show_id": 35935}],
+        "tv_season_results": [],
+    }
+
+
+def test_find_tmdb_id_by_external_id_prefers_episode_result_on_collision(
+    translator: Translator, mock_find_tvdb_collision_response: dict[str, Any]
+) -> None:
+    """Prefer the episode's parent when TVDB IDs collide across resource types."""
+    with patch.object(translator.client, "get") as mock_get:
+        mock_response = Mock()
+        mock_response.raise_for_status.return_value = None
+        mock_response.json.return_value = mock_find_tvdb_collision_response
+        mock_get.return_value = mock_response
+
+        result = translator.find_tmdb_id_by_external_id(
+            "127401", "tvdb_id", resource_type="episode"
+        )
+
+        assert result == 35935
+        mock_get.assert_called_once_with(
+            "/find/127401", params={"external_source": "tvdb_id"}
+        )
+
+
+def test_find_tmdb_id_by_external_id_uses_tv_result_for_series_collision(
+    translator: Translator, mock_find_tvdb_collision_response: dict[str, Any]
+) -> None:
+    """Use the TV result when resolving a series NFO with a colliding ID."""
+    with patch.object(translator.client, "get") as mock_get:
+        mock_response = Mock()
+        mock_response.raise_for_status.return_value = None
+        mock_response.json.return_value = mock_find_tvdb_collision_response
+        mock_get.return_value = mock_response
+
+        result = translator.find_tmdb_id_by_external_id("127401", "tvdb_id")
+
+        assert result == 23747
 
 
 def test_find_tmdb_id_by_external_id_imdb_success(


### PR DESCRIPTION
## Background
Follow-up to #105 and #106. Some episode TVDB IDs collide with unrelated TV series IDs in TMDB find responses.

## Root Cause
TMDB `/find/{external_id}` can return both `tv_results` and `tv_episode_results`. Lookup did not know whether NFO represented a series or episode, so episode IDs could resolve to an unrelated series.

## Changes
- Select `tv_results[].id` for series resources.
- Select `tv_episode_results[].show_id` for episode resources.
- Add unit coverage for both collision directions.
- Add live TMDB integration coverage for Berserk S01E06 and S01E16.

Refs #105
Refs #106