### PR TITLE
fix: support Kodi combination NFO URLs

### DIFF
--- a/src/sonarr_metadata_rewrite/file_utils.py
+++ b/src/sonarr_metadata_rewrite/file_utils.py
@@ -14,6 +14,10 @@ from sonarr_metadata_rewrite.retry_utils import retry
 
 # Supported image extensions (lowercase with leading dot)
 IMAGE_EXTENSIONS: set[str] = {".jpg", ".jpeg", ".png"}
+TRAILING_SCRAPER_URLS_RE = re.compile(
+    r"(?P<suffix>(?:[ \t]*\r?\n)+[ \t]*https?://[^\s<>]+"
+    r"(?:[ \t]*\r?\n[ \t]*https?://[^\s<>]+)*(?:[ \t]*\r?\n)*)\Z"
+)
 
 
 def parse_image_info(basename: str) -> tuple[str, int | None]:
@@ -167,26 +171,45 @@ def extract_metadata_info(nfo_path: Path) -> MetadataInfo:
 
 def _parse_nfo_documents(nfo_path: Path) -> MetadataInfo:
     """Parse one or more adjacent XML documents from an NFO file."""
-    raw_content = nfo_path.read_text(encoding="utf-8")
-    normalized_content = raw_content.strip()
+    raw_content = nfo_path.read_bytes().decode("utf-8")
+    xml_content, scraper_url_suffix = _split_trailing_scraper_url_suffix(raw_content)
+    normalized_content = xml_content.strip()
     normalized_content = re.sub(r"<\?xml[^>]*\?>", "", normalized_content).strip()
     wrapped_content = f"<nfo-root>{normalized_content}</nfo-root>"
     wrapped_root = ET.fromstring(wrapped_content)
 
     if not list(wrapped_root):
         raise ET.ParseError("No XML document found")
+    if wrapped_root.text and not wrapped_root.text.isspace():
+        raise ET.ParseError("Invalid text outside NFO XML document")
+    if any(child.tail and not child.tail.isspace() for child in wrapped_root):
+        raise ET.ParseError("Invalid text outside NFO XML document")
 
     if len(wrapped_root) == 1:
         root = wrapped_root[0]
         if root.tag == "tvshow":
-            return _extract_tvshow_metadata(root)
+            metadata = _extract_tvshow_metadata(root)
+            metadata.trailing_scraper_url_suffix = scraper_url_suffix
+            return metadata
         if root.tag == "movie":
-            return _extract_movie_metadata(root)
+            metadata = _extract_movie_metadata(root)
+            metadata.trailing_scraper_url_suffix = scraper_url_suffix
+            return metadata
 
     if all(child.tag == "episodedetails" for child in wrapped_root):
-        return _extract_episode_metadata(wrapped_root)
+        metadata = _extract_episode_metadata(wrapped_root)
+        metadata.trailing_scraper_url_suffix = scraper_url_suffix
+        return metadata
 
     raise ET.ParseError("Unsupported NFO root structure")
+
+
+def _split_trailing_scraper_url_suffix(content: str) -> tuple[str, str]:
+    """Separate Kodi combination-NFO scraper URLs from XML content."""
+    match = TRAILING_SCRAPER_URLS_RE.search(content)
+    if match is None:
+        return content, ""
+    return content[: match.start()], match.group("suffix")
 
 
 def _extract_tvshow_metadata(root: ET.Element) -> MetadataInfo:

--- a/src/sonarr_metadata_rewrite/file_utils.py
+++ b/src/sonarr_metadata_rewrite/file_utils.py
@@ -172,7 +172,7 @@ def extract_metadata_info(nfo_path: Path) -> MetadataInfo:
 def _parse_nfo_documents(nfo_path: Path) -> MetadataInfo:
     """Parse one or more adjacent XML documents from an NFO file."""
     raw_content = nfo_path.read_bytes().decode("utf-8")
-    xml_content, scraper_url_suffix = _split_trailing_scraper_url_suffix(raw_content)
+    xml_content, scraper_urls = _split_trailing_scraper_urls(raw_content)
     normalized_content = xml_content.strip()
     normalized_content = re.sub(r"<\?xml[^>]*\?>", "", normalized_content).strip()
     wrapped_content = f"<nfo-root>{normalized_content}</nfo-root>"
@@ -189,22 +189,22 @@ def _parse_nfo_documents(nfo_path: Path) -> MetadataInfo:
         root = wrapped_root[0]
         if root.tag == "tvshow":
             metadata = _extract_tvshow_metadata(root)
-            metadata.trailing_scraper_url_suffix = scraper_url_suffix
+            metadata.trailing_scraper_urls = scraper_urls
             return metadata
         if root.tag == "movie":
             metadata = _extract_movie_metadata(root)
-            metadata.trailing_scraper_url_suffix = scraper_url_suffix
+            metadata.trailing_scraper_urls = scraper_urls
             return metadata
 
     if all(child.tag == "episodedetails" for child in wrapped_root):
         metadata = _extract_episode_metadata(wrapped_root)
-        metadata.trailing_scraper_url_suffix = scraper_url_suffix
+        metadata.trailing_scraper_urls = scraper_urls
         return metadata
 
     raise ET.ParseError("Unsupported NFO root structure")
 
 
-def _split_trailing_scraper_url_suffix(content: str) -> tuple[str, str]:
+def _split_trailing_scraper_urls(content: str) -> tuple[str, str]:
     """Separate Kodi combination-NFO scraper URLs from XML content."""
     match = TRAILING_SCRAPER_URLS_RE.search(content)
     if match is None:

--- a/src/sonarr_metadata_rewrite/metadata_processor.py
+++ b/src/sonarr_metadata_rewrite/metadata_processor.py
@@ -140,7 +140,10 @@ class MetadataProcessor:
         )
 
         self._write_translated_metadata_with_tree(
-            metadata_info.xml_tree, nfo_path, selected_translation
+            metadata_info.xml_tree,
+            nfo_path,
+            selected_translation,
+            metadata_info.trailing_scraper_url_suffix,
         )
 
         return MetadataProcessResult(
@@ -303,7 +306,10 @@ class MetadataProcessor:
             self.settings.rewrite_root_dirs,
         )
         self._write_translated_episode_entries(
-            episode_entries, nfo_path, updated_translations
+            episode_entries,
+            nfo_path,
+            updated_translations,
+            metadata_info.trailing_scraper_url_suffix,
         )
 
         message = self._build_multi_episode_message(
@@ -645,6 +651,7 @@ class MetadataProcessor:
         xml_tree: ET.ElementTree | None,
         nfo_path: Path,
         translation: TranslatedContent,
+        trailing_scraper_url_suffix: str = "",
     ) -> None:
         """Write translated metadata using cached XML tree.
 
@@ -652,6 +659,7 @@ class MetadataProcessor:
             xml_tree: Cached XML tree from metadata extraction
             nfo_path: Path to .nfo file to update
             translation: Translated content
+            trailing_scraper_url_suffix: Raw scraper URLs after XML content
 
         Raises:
             Exception: If write operation fails
@@ -683,6 +691,8 @@ class MetadataProcessor:
             xml_tree.write(
                 temp_path, encoding="utf-8", xml_declaration=True, method="xml"
             )
+            with temp_path.open("ab") as temp_file:
+                temp_file.write(trailing_scraper_url_suffix.encode("utf-8"))
 
             # Atomic replacement
             temp_path.replace(nfo_path)
@@ -698,6 +708,7 @@ class MetadataProcessor:
         episode_entries: list[EpisodeMetadataInfo],
         nfo_path: Path,
         updated_translations: dict[int, TranslatedContent],
+        trailing_scraper_url_suffix: str = "",
     ) -> None:
         """Write translated content for one or more episode XML documents."""
         temp_path = nfo_path.with_suffix(".nfo.tmp")
@@ -729,7 +740,9 @@ class MetadataProcessor:
                 + "\n".join(serialized_documents)
                 + "\n"
             )
-            temp_path.write_text(content, encoding="utf-8")
+            temp_path.write_bytes(
+                content.encode("utf-8") + trailing_scraper_url_suffix.encode("utf-8")
+            )
             temp_path.replace(nfo_path)
         except Exception:
             if temp_path.exists():

--- a/src/sonarr_metadata_rewrite/metadata_processor.py
+++ b/src/sonarr_metadata_rewrite/metadata_processor.py
@@ -143,7 +143,7 @@ class MetadataProcessor:
             metadata_info.xml_tree,
             nfo_path,
             selected_translation,
-            metadata_info.trailing_scraper_url_suffix,
+            metadata_info.trailing_scraper_urls,
         )
 
         return MetadataProcessResult(
@@ -309,7 +309,7 @@ class MetadataProcessor:
             episode_entries,
             nfo_path,
             updated_translations,
-            metadata_info.trailing_scraper_url_suffix,
+            metadata_info.trailing_scraper_urls,
         )
 
         message = self._build_multi_episode_message(
@@ -651,7 +651,7 @@ class MetadataProcessor:
         xml_tree: ET.ElementTree | None,
         nfo_path: Path,
         translation: TranslatedContent,
-        trailing_scraper_url_suffix: str = "",
+        trailing_scraper_urls: str = "",
     ) -> None:
         """Write translated metadata using cached XML tree.
 
@@ -659,7 +659,7 @@ class MetadataProcessor:
             xml_tree: Cached XML tree from metadata extraction
             nfo_path: Path to .nfo file to update
             translation: Translated content
-            trailing_scraper_url_suffix: Raw scraper URLs after XML content
+            trailing_scraper_urls: Raw scraper URLs after XML content
 
         Raises:
             Exception: If write operation fails
@@ -692,7 +692,7 @@ class MetadataProcessor:
                 temp_path, encoding="utf-8", xml_declaration=True, method="xml"
             )
             with temp_path.open("ab") as temp_file:
-                temp_file.write(trailing_scraper_url_suffix.encode("utf-8"))
+                temp_file.write(trailing_scraper_urls.encode("utf-8"))
 
             # Atomic replacement
             temp_path.replace(nfo_path)
@@ -708,7 +708,7 @@ class MetadataProcessor:
         episode_entries: list[EpisodeMetadataInfo],
         nfo_path: Path,
         updated_translations: dict[int, TranslatedContent],
-        trailing_scraper_url_suffix: str = "",
+        trailing_scraper_urls: str = "",
     ) -> None:
         """Write translated content for one or more episode XML documents."""
         temp_path = nfo_path.with_suffix(".nfo.tmp")
@@ -741,7 +741,7 @@ class MetadataProcessor:
                 + "\n"
             )
             temp_path.write_bytes(
-                content.encode("utf-8") + trailing_scraper_url_suffix.encode("utf-8")
+                content.encode("utf-8") + trailing_scraper_urls.encode("utf-8")
             )
             temp_path.replace(nfo_path)
         except Exception:

--- a/src/sonarr_metadata_rewrite/models.py
+++ b/src/sonarr_metadata_rewrite/models.py
@@ -74,6 +74,7 @@ class MetadataInfo:
     # Raw XML for writing
     xml_tree: ET.ElementTree | None = None
     episode_entries: list[EpisodeMetadataInfo] | None = None
+    trailing_scraper_url_suffix: str = ""
 
 
 @dataclass

--- a/src/sonarr_metadata_rewrite/models.py
+++ b/src/sonarr_metadata_rewrite/models.py
@@ -74,7 +74,8 @@ class MetadataInfo:
     # Raw XML for writing
     xml_tree: ET.ElementTree | None = None
     episode_entries: list[EpisodeMetadataInfo] | None = None
-    trailing_scraper_url_suffix: str = ""
+    # Raw HTTP(S) URL block after XML, including original newlines and multiple URLs.
+    trailing_scraper_urls: str = ""
 
 
 @dataclass

--- a/tests/integration/fixtures/radarr_client.py
+++ b/tests/integration/fixtures/radarr_client.py
@@ -75,12 +75,15 @@ class RadarrClient(ArrClient):
         response.raise_for_status()
         return cast(dict[str, Any], response.json())
 
-    def configure_metadata_settings(self, use_movie_nfo: bool) -> bool:
+    def configure_metadata_settings(
+        self, use_movie_nfo: bool, movie_metadata_url: bool = False
+    ) -> bool:
         """Enable Kodi/Emby movie metadata and images for selected NFO mode."""
         return self._configure_metadata_settings(
             provider_names=("kodi", "xbmc", "emby"),
             field_values={
                 "moviemetadata": True,
+                "moviemetadataurl": movie_metadata_url,
                 "movieimages": True,
                 "usemovienfo": use_movie_nfo,
             },

--- a/tests/integration/fixtures/sonarr_client.py
+++ b/tests/integration/fixtures/sonarr_client.py
@@ -106,7 +106,7 @@ class SonarrClient(ArrClient):
             print(f"Response: {response.text}")
             return []
 
-    def configure_metadata_settings(self) -> bool:
+    def configure_metadata_settings(self, series_metadata_url: bool = False) -> bool:
         """Configure Sonarr to enable NFO metadata generation.
 
         Returns:
@@ -116,6 +116,7 @@ class SonarrClient(ArrClient):
             provider_names=("kodi", "xbmc"),
             field_values={
                 "seriesmetadata": True,
+                "seriesmetadataurl": series_metadata_url,
                 "episodemetadata": True,
                 "episodeimages": True,
                 "seriesimages": True,

--- a/tests/integration/test_radarr_integration.py
+++ b/tests/integration/test_radarr_integration.py
@@ -86,6 +86,57 @@ def test_radarr_movie_metadata_and_images(
 
 @pytest.mark.integration
 @pytest.mark.slow
+def test_movie_metadata_url_nfo_rewrite(
+    temp_radarr_media_root: Path,
+    radarr_container: RadarrClient,
+) -> None:
+    """Rewrite a real Radarr combination NFO without losing scraper URLs."""
+    assert radarr_container.configure_metadata_settings(
+        use_movie_nfo=True, movie_metadata_url=True
+    ), "Failed to enable Radarr movie metadata URL"
+
+    expected_urls = [
+        "https://www.themoviedb.org/movie/550",
+        "https://www.imdb.com/title/tt0137523",
+    ]
+    try:
+        with MovieWithNfos(
+            radarr_container,
+            temp_radarr_media_root,
+            FIGHT_CLUB_TMDB_ID,
+            use_movie_nfo=True,
+        ) as (nfo_file, _):
+            original_content = nfo_file.read_text(encoding="utf-8")
+            original_xml, closing_tag, original_suffix = original_content.partition(
+                "</movie>"
+            )
+            assert closing_tag == "</movie>"
+            assert "<movie>" in original_xml
+            assert original_suffix.splitlines() == ["", *expected_urls]
+
+            with ServiceRunner(
+                temp_radarr_media_root,
+                {
+                    "ENABLE_FILE_MONITOR": "false",
+                    "ENABLE_IMAGE_REWRITE": "false",
+                },
+            ):
+                verify_translations([nfo_file], "zh", ["zh", "en"])
+
+            _, closing_tag, rewritten_suffix = nfo_file.read_text(
+                encoding="utf-8"
+            ).partition("</movie>")
+            assert closing_tag == "</movie>"
+            assert rewritten_suffix == original_suffix
+            assert rewritten_suffix.splitlines() == ["", *expected_urls]
+    finally:
+        assert radarr_container.configure_metadata_settings(
+            use_movie_nfo=True, movie_metadata_url=False
+        ), "Failed to reset Radarr movie metadata URL"
+
+
+@pytest.mark.integration
+@pytest.mark.slow
 @pytest.mark.parametrize(
     "use_movie_nfo",
     [True, False],

--- a/tests/integration/test_sonarr_integration.py
+++ b/tests/integration/test_sonarr_integration.py
@@ -321,6 +321,61 @@ def test_episode_tvdb_external_id_lookup(
 
 @pytest.mark.integration
 @pytest.mark.slow
+def test_series_metadata_url_nfo_rewrite(
+    temp_sonarr_media_root: Path,
+    configured_sonarr_container: SonarrClient,
+) -> None:
+    """Rewrite a real Sonarr combination NFO without losing its scraper URL."""
+    assert configured_sonarr_container.configure_metadata_settings(
+        series_metadata_url=True
+    ), "Failed to enable Sonarr series metadata URL"
+
+    try:
+        with SeriesWithNfos(
+            configured_sonarr_container,
+            temp_sonarr_media_root,
+            BREAKING_BAD_TVDB_ID,
+            [],
+        ) as (nfo_files, _):
+            tvshow_nfo = next(
+                nfo_path for nfo_path in nfo_files if nfo_path.name == "tvshow.nfo"
+            )
+            original_content = tvshow_nfo.read_text(encoding="utf-8")
+            original_xml, closing_tag, original_suffix = original_content.partition(
+                "</tvshow>"
+            )
+            assert closing_tag == "</tvshow>"
+            assert "<tvshow>" in original_xml
+            assert original_suffix == (
+                f"\nhttps://www.thetvdb.com/?tab=series&id={BREAKING_BAD_TVDB_ID}"
+            )
+
+            with ServiceRunner(
+                temp_sonarr_media_root,
+                {
+                    "ENABLE_FILE_MONITOR": "false",
+                    "ENABLE_IMAGE_REWRITE": "false",
+                },
+            ):
+                verify_translations(
+                    [tvshow_nfo],
+                    expected_language="zh",
+                    possible_languages=["zh", "en"],
+                )
+
+            _, closing_tag, rewritten_suffix = tvshow_nfo.read_text(
+                encoding="utf-8"
+            ).partition("</tvshow>")
+            assert closing_tag == "</tvshow>"
+            assert rewritten_suffix == original_suffix
+    finally:
+        assert configured_sonarr_container.configure_metadata_settings(
+            series_metadata_url=False
+        ), "Failed to reset Sonarr series metadata URL"
+
+
+@pytest.mark.integration
+@pytest.mark.slow
 def test_multi_episode_nfo_rewrite_and_rollback(
     temp_sonarr_media_root: Path,
     configured_sonarr_container: SonarrClient,

--- a/tests/unit/test_file_utils.py
+++ b/tests/unit/test_file_utils.py
@@ -399,7 +399,7 @@ class TestExtractMetadataInfo:
 
         assert metadata.file_type == "tvshow"
         assert metadata.tmdb_id == 123
-        assert metadata.trailing_scraper_url_suffix == suffix
+        assert metadata.trailing_scraper_urls == suffix
 
     def test_extract_movie_metadata_with_scraper_urls(
         self, test_data_dir: Path
@@ -425,7 +425,7 @@ class TestExtractMetadataInfo:
 
         assert metadata.file_type == "movie"
         assert metadata.tmdb_id == 550
-        assert metadata.trailing_scraper_url_suffix == suffix
+        assert metadata.trailing_scraper_urls == suffix
 
     def test_extract_metadata_info_rejects_unsupported_multi_root_content(
         self, test_data_dir: Path

--- a/tests/unit/test_file_utils.py
+++ b/tests/unit/test_file_utils.py
@@ -378,6 +378,55 @@ class TestExtractMetadataInfo:
         assert metadata.imdb_id == "tt0959621"
         assert metadata.tmdb_id is None
 
+    def test_extract_tvshow_metadata_with_scraper_url(
+        self, test_data_dir: Path
+    ) -> None:
+        """Extract Sonarr metadata without parsing its trailing scraper URL as XML."""
+        suffix = "\nhttps://www.thetvdb.com/?tab=series&id=456813"
+        nfo_path = test_data_dir / "tvshow.nfo"
+        nfo_path.write_text(
+            """<?xml version="1.0" encoding="utf-8"?>
+<tvshow>
+  <title>Cape Fear</title>
+  <plot>A modern retelling.</plot>
+  <uniqueid type="tmdb">123</uniqueid>
+</tvshow>"""
+            + suffix,
+            encoding="utf-8",
+        )
+
+        metadata = extract_metadata_info(nfo_path)
+
+        assert metadata.file_type == "tvshow"
+        assert metadata.tmdb_id == 123
+        assert metadata.trailing_scraper_url_suffix == suffix
+
+    def test_extract_movie_metadata_with_scraper_urls(
+        self, test_data_dir: Path
+    ) -> None:
+        """Extract Radarr metadata with its two trailing scraper URLs."""
+        suffix = (
+            "\nhttps://www.themoviedb.org/movie/550"
+            "\nhttps://www.imdb.com/title/tt0137523"
+        )
+        nfo_path = test_data_dir / "movie.nfo"
+        nfo_path.write_text(
+            """<?xml version="1.0" encoding="utf-8"?>
+<movie>
+  <title>Fight Club</title>
+  <plot>Rules are made to be broken.</plot>
+  <uniqueid type="tmdb">550</uniqueid>
+</movie>"""
+            + suffix,
+            encoding="utf-8",
+        )
+
+        metadata = extract_metadata_info(nfo_path)
+
+        assert metadata.file_type == "movie"
+        assert metadata.tmdb_id == 550
+        assert metadata.trailing_scraper_url_suffix == suffix
+
     def test_extract_metadata_info_rejects_unsupported_multi_root_content(
         self, test_data_dir: Path
     ) -> None:

--- a/tests/unit/test_file_utils.py
+++ b/tests/unit/test_file_utils.py
@@ -427,6 +427,24 @@ class TestExtractMetadataInfo:
         assert metadata.tmdb_id == 550
         assert metadata.trailing_scraper_urls == suffix
 
+    @pytest.mark.parametrize(
+        "content",
+        [
+            "Unexpected text\n<tvshow><title>Series</title></tvshow>",
+            "<tvshow><title>Series</title></tvshow>\nUnexpected text",
+        ],
+        ids=["before-xml", "after-xml"],
+    )
+    def test_extract_metadata_rejects_non_url_text_outside_xml(
+        self, test_data_dir: Path, content: str
+    ) -> None:
+        """Reject text outside XML unless it is a trailing scraper URL."""
+        nfo_path = test_data_dir / "invalid.nfo"
+        nfo_path.write_text(content, encoding="utf-8")
+
+        with pytest.raises(ET.ParseError, match="Invalid text outside NFO XML"):
+            extract_metadata_info(nfo_path)
+
     def test_extract_metadata_info_rejects_unsupported_multi_root_content(
         self, test_data_dir: Path
     ) -> None:

--- a/tests/unit/test_integration_fixtures.py
+++ b/tests/unit/test_integration_fixtures.py
@@ -66,6 +66,7 @@ def test_arr_command_failure_is_not_retried(
                 "name": "Kodi (XBMC)",
                 "fields": [
                     {"name": "seriesMetadata", "value": False},
+                    {"name": "seriesMetadataUrl", "value": False},
                     {"name": "episodeMetadata", "value": False},
                     {"name": "episodeImages", "value": False},
                     {"name": "seriesImages", "value": False},
@@ -102,7 +103,7 @@ def test_arr_metadata_configuration_waits_for_provider(
                 assert client.configure_metadata_settings(use_movie_nfo=True)
             else:
                 assert isinstance(client, SonarrClient)
-                assert client.configure_metadata_settings()
+                assert client.configure_metadata_settings(series_metadata_url=True)
     finally:
         client.close()
 

--- a/tests/unit/test_integration_fixtures.py
+++ b/tests/unit/test_integration_fixtures.py
@@ -53,6 +53,7 @@ def test_arr_command_failure_is_not_retried(
                 "name": "Kodi (XMBC) / Emby",
                 "fields": [
                     {"name": "movieMetadata", "value": False},
+                    {"name": "movieMetadataUrl", "value": False},
                     {"name": "movieImages", "value": False},
                     {"name": "UseMovieNfo", "value": False},
                 ],
@@ -100,7 +101,9 @@ def test_arr_metadata_configuration_waits_for_provider(
         ):
             if is_radarr:
                 assert isinstance(client, RadarrClient)
-                assert client.configure_metadata_settings(use_movie_nfo=True)
+                assert client.configure_metadata_settings(
+                    use_movie_nfo=True, movie_metadata_url=True
+                )
             else:
                 assert isinstance(client, SonarrClient)
                 assert client.configure_metadata_settings(series_metadata_url=True)

--- a/tests/unit/test_metadata_processor.py
+++ b/tests/unit/test_metadata_processor.py
@@ -148,6 +148,47 @@ def test_process_file_movie_parses_and_preserves_other_xml_fields(
     assert root.findtext("watched") == "false"
 
 
+@pytest.mark.parametrize(
+    ("sample_name", "tmdb_id", "suffix"),
+    [
+        (
+            "tvshow.nfo",
+            1396,
+            "\nhttps://www.thetvdb.com/?tab=series&id=81189",
+        ),
+        (
+            "movie.nfo",
+            550,
+            "\nhttps://www.themoviedb.org/movie/550"
+            "\nhttps://www.imdb.com/title/tt0137523",
+        ),
+    ],
+    ids=["sonarr-tvshow", "radarr-movie"],
+)
+def test_process_file_preserves_scraper_url_suffix(
+    processor: MetadataProcessor,
+    test_data_dir: Path,
+    create_test_files: Callable[[str, Path], Path],
+    sample_name: str,
+    tmdb_id: int,
+    suffix: str,
+) -> None:
+    """Rewrite combination NFOs without dropping their trailing scraper URLs."""
+    nfo_path = create_test_files(sample_name, test_data_dir / sample_name)
+    nfo_path.write_text(nfo_path.read_text(encoding="utf-8") + suffix, encoding="utf-8")
+
+    result = processor.process_file(nfo_path)
+
+    assert_process_result(
+        result,
+        expected_success=True,
+        expected_tmdb_id=tmdb_id,
+        expected_file_modified=True,
+        expected_language="zh-CN",
+    )
+    assert nfo_path.read_bytes().endswith(suffix.encode("utf-8"))
+
+
 def test_process_file_movie_without_tmdb_id_skips_external_resolution(
     processor: MetadataProcessor,
     test_data_dir: Path,
@@ -1622,6 +1663,8 @@ def test_process_file_multi_episode_partial_update(
         test_data_dir, create_test_files
     )
     nfo_path = create_test_files("multi_episode.nfo", series_dir / "episodes.nfo")
+    suffix = "\nhttps://www.thetvdb.com/?tab=series&id=81189"
+    nfo_path.write_text(nfo_path.read_text(encoding="utf-8") + suffix, encoding="utf-8")
 
     def get_translations(tmdb_ids: TmdbIds) -> dict[str, TranslatedContent]:
         if tmdb_ids.episode == 1:
@@ -1651,6 +1694,7 @@ def test_process_file_multi_episode_partial_update(
     assert "沃尔特开始了犯罪生涯。" in content
     assert "Cat's in the Bag..." in content
     assert "Walt and Jesse deal with the aftermath." in content
+    assert content.endswith(suffix)
 
 
 def test_process_file_multi_episode_restore_from_backup_when_translation_missing(


### PR DESCRIPTION
## Background

Kodi documents this format as a [Combination NFO](https://kodi.wiki/view/NFO_files/Combination): metadata XML followed by a scraper URL. This is supported for Movies and TV Shows.

Sonarr [conditionally appends a TheTVDB URL](https://github.com/Sonarr/Sonarr/blob/develop/src/NzbDrone.Core/Extras/Metadata/Consumers/Xbmc/XbmcMetadata.cs) when Kodi/XBMC `Series Metadata` and `Series Metadata URL` are enabled. Radarr [appends TMDB and IMDb URLs](https://github.com/Radarr/Radarr/blob/develop/src/NzbDrone.Core/Extras/Metadata/Consumers/Xbmc/XbmcMetadata.cs) when `Movie Metadata URL` is enabled.

## When Users Create This Format

Both URL options are Advanced and disabled by default. In either application, go to **Settings > Metadata**, enable and open **Kodi (XBMC) / Emby**, then enable **Show Advanced Settings**.

| Application | Required metadata options | Result |
| --- | --- | --- |
| Sonarr | `Series Metadata` and `Series Metadata URL` | Full `tvshow.nfo`, followed by a TheTVDB series URL |
| Radarr | `Movie Metadata` and `Movie Metadata URL` | Full movie NFO, followed by TMDB and IMDb URLs |

Enabling only the URL option creates a URL-only parsing NFO. Enabling both options creates the Combination NFO handled by this PR.

## Sonarr Example

```xml
<?xml version="1.0" encoding="utf-8" standalone="yes"?>
<tvshow>
  <title>Cape Fear</title>
  <uniqueid type="tvdb">456813</uniqueid>
</tvshow>
https://www.thetvdb.com/?tab=series&id=456813
```

The trailing bare `&` means this is not a standalone XML document, but it is valid Kodi Combination NFO content.

## Root Cause

The parser wrapped scraper URLs as XML text. Sonarr URLs containing raw `&` failed immediately, while Radarr URLs failed when cloning the XML root.

## Behavior

Trailing HTTP(S) scraper URL blocks are separated before XML parsing and appended unchanged after rewritten XML. This preserves Sonarr series URLs, Radarr movie URLs, and multi-episode suffixes.

## Test Coverage

Unit coverage verifies Sonarr, Radarr, and multi-episode suffix preservation. Real Sonarr and Radarr container tests enable their URL settings, generate combination NFOs, rewrite them, and preserve the original URL suffixes. The Radarr test explicitly asserts both the TMDB and IMDb URLs.

Closes #105