### PR TITLE
fix: prefer original-language metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,12 @@ SERVICE_MODE=rewrite                  # Service mode: 'rewrite' or 'rollback'
 You can list multiple languages separated by commas - it'll try them in
 order.
 
+At startup, the service logs both your configured list and its runtime list.
+The runtime list removes duplicate codes and adds each base language after its
+last configured locale variant. For example, `de-DE,fr-FR,fr-CA,en-US` becomes
+`de-DE,de,fr-FR,fr-CA,fr,en-US,en`. Images still use only the configured
+language-country codes.
+
 ### Which images are rewritten?
 
 If image rewriting is enabled, the service recognizes these filenames:
@@ -263,7 +269,8 @@ You'll see something like:
 ✅ TMDB API key loaded (ending in ...xyz)
 📁 Monitoring directory: /tv
 📁 Monitoring directory: /anime
-🌍 Preferred languages: ['zh-CN', 'ja-JP']
+🌍 Configured preferred languages: ['zh-CN', 'ja-JP']
+🌍 Runtime preferred languages: ['zh-CN', 'zh', 'ja-JP', 'ja']
 ✅ Service started successfully
 ```
 

--- a/README.md
+++ b/README.md
@@ -164,12 +164,6 @@ SERVICE_MODE=rewrite                  # Service mode: 'rewrite' or 'rollback'
 You can list multiple languages separated by commas - it'll try them in
 order.
 
-At startup, the service logs both your configured list and its runtime list.
-The runtime list removes duplicate codes and adds each base language after its
-last configured locale variant. For example, `de-DE,fr-FR,fr-CA,en-US` becomes
-`de-DE,de,fr-FR,fr-CA,fr,en-US,en`. Images still use only the configured
-language-country codes.
-
 ### Which images are rewritten?
 
 If image rewriting is enabled, the service recognizes these filenames:

--- a/src/sonarr_metadata_rewrite/metadata_processor.py
+++ b/src/sonarr_metadata_rewrite/metadata_processor.py
@@ -28,6 +28,9 @@ class MetadataProcessor:
         """Initialize processor with settings and TMDB translator."""
         self.settings = settings
         self.translator = translator
+        self.effective_preferred_languages = self._build_effective_preferred_languages(
+            settings.preferred_languages
+        )
 
     def process_file(self, nfo_path: Path) -> MetadataProcessResult:
         """Process a single .nfo file with complete translation workflow.
@@ -77,7 +80,9 @@ class MetadataProcessor:
             )
 
         all_translations = self.translator.get_translations(tmdb_ids)
-        selected_translation = self._select_preferred_translation(all_translations)
+        selected_translation = self._select_translation_with_original_content(
+            all_translations, tmdb_ids
+        )
 
         if not selected_translation:
             original_metadata = self._get_backup_metadata_info(nfo_path)
@@ -222,7 +227,9 @@ class MetadataProcessor:
                 first_tmdb_ids = entry_tmdb_ids
 
             all_translations = self.translator.get_translations(entry_tmdb_ids)
-            entry_translation = self._select_preferred_translation(all_translations)
+            entry_translation = self._select_translation_with_original_content(
+                all_translations, entry_tmdb_ids
+            )
 
             entry_metadata = self._build_episode_metadata_info(entry, series_tmdb_id)
             if not entry_translation:
@@ -765,7 +772,7 @@ class MetadataProcessor:
         tagline_string = None
 
         # Find best title, description, and tagline from preferred languages.
-        for preferred_lang in self.settings.preferred_languages:
+        for preferred_lang in self._expanded_preferred_languages():
             if preferred_lang in all_translations:
                 translation = all_translations[preferred_lang]
 
@@ -796,6 +803,82 @@ class MetadataProcessor:
             )
 
         return None
+
+    def _select_translation_with_original_content(
+        self,
+        all_translations: dict[str, TranslatedContent],
+        tmdb_ids: TmdbIds,
+    ) -> TranslatedContent | None:
+        """Select translations with original-language content as a fallback."""
+        try:
+            original_details = self.translator.get_original_details(tmdb_ids)
+            if not isinstance(original_details, tuple):
+                return self._select_preferred_translation(all_translations)
+            original_language, _ = original_details
+            if original_language not in self._expanded_preferred_languages():
+                return self._select_preferred_translation(all_translations)
+            original_translation = self.translator.get_original_translation(
+                tmdb_ids, original_language
+            )
+            if not isinstance(original_translation, TranslatedContent):
+                return self._select_preferred_translation(all_translations)
+        except Exception:
+            return self._select_preferred_translation(all_translations)
+
+        existing_translation = all_translations.get(original_language)
+        translations_with_original_content = dict(all_translations)
+        translations_with_original_content[original_language] = TranslatedContent(
+            title=(
+                existing_translation.title
+                if existing_translation is not None
+                and existing_translation.title.content
+                else original_translation.title
+            ),
+            description=(
+                existing_translation.description
+                if existing_translation is not None
+                and existing_translation.description.content
+                else original_translation.description
+            ),
+            tagline=(
+                existing_translation.tagline
+                if existing_translation is not None
+                and existing_translation.tagline.content
+                else original_translation.tagline
+            ),
+        )
+        return self._select_preferred_translation(translations_with_original_content)
+
+    def _expanded_preferred_languages(self) -> list[str]:
+        """Return the NFO fallback candidates calculated during initialization."""
+        return self.effective_preferred_languages
+
+    @staticmethod
+    def _build_effective_preferred_languages(
+        configured_languages: list[str],
+    ) -> list[str]:
+        """Add a base-language candidate after its final configured locale.
+
+        Exact duplicate locales are removed while preserving their first priority.
+        This lets original-language metadata follow every configured regional
+        translation for the same language.
+        """
+        languages: list[str] = []
+        preferred_languages = list(dict.fromkeys(configured_languages))
+        last_index_by_base_language = {
+            language.split("-", 1)[0]: index
+            for index, language in enumerate(preferred_languages)
+        }
+        for index, preferred_language in enumerate(preferred_languages):
+            languages.append(preferred_language)
+            base_language = preferred_language.split("-", 1)[0]
+            if (
+                last_index_by_base_language[base_language] == index
+                and base_language not in languages
+            ):
+                languages.append(base_language)
+
+        return languages
 
     def _build_success_message(self, translation: TranslatedContent) -> str:
         """Build success message showing source languages for translated fields.

--- a/src/sonarr_metadata_rewrite/rewrite_service.py
+++ b/src/sonarr_metadata_rewrite/rewrite_service.py
@@ -43,7 +43,13 @@ class RewriteService:
         logger.info("Starting Sonarr and Radarr Metadata Rewrite Service")
         for root_dir in self.settings.rewrite_root_dirs:
             logger.info(f"Monitoring directory: {root_dir}")
-        logger.info(f"Preferred languages: {self.settings.preferred_languages}")
+        logger.info(
+            f"Configured preferred languages: {self.settings.preferred_languages}"
+        )
+        logger.info(
+            "Runtime preferred languages: "
+            f"{self.metadata_processor.effective_preferred_languages}"
+        )
 
         # Start real-time file monitoring if enabled
         if self.settings.enable_file_monitor:

--- a/src/sonarr_metadata_rewrite/translator.py
+++ b/src/sonarr_metadata_rewrite/translator.py
@@ -213,6 +213,36 @@ class Translator:
 
         return None
 
+    def get_original_translation(
+        self, tmdb_ids: TmdbIds, language: str
+    ) -> TranslatedContent | None:
+        """Get original-language metadata localized with its base language code."""
+        endpoint = f"/{tmdb_ids}"
+        api_data = self._get_cached_json(endpoint, {"language": language})
+        if api_data is None:
+            return None
+
+        if tmdb_ids.media_type == "movie":
+            title = api_data.get("original_title", "").strip()
+            if not title:
+                title = api_data.get("title", "").strip()
+        elif tmdb_ids.season is not None and tmdb_ids.episode is not None:
+            title = api_data.get("name", "").strip()
+        else:
+            title = api_data.get("original_name", "").strip()
+            if not title:
+                title = api_data.get("name", "").strip()
+
+        return TranslatedContent(
+            title=TranslatedString(content=title, language="original"),
+            description=TranslatedString(
+                content=api_data.get("overview", "").strip(), language="original"
+            ),
+            tagline=TranslatedString(
+                content=api_data.get("tagline", "").strip(), language="original"
+            ),
+        )
+
     def find_tmdb_id_by_external_id(
         self,
         external_id: str,

--- a/tests/integration/fixtures/arr_client.py
+++ b/tests/integration/fixtures/arr_client.py
@@ -129,7 +129,7 @@ class ArrClient:
         check_command()
 
     def _configure_metadata_settings(
-        self, provider_names: tuple[str, ...], field_values: dict[str, bool]
+        self, provider_names: tuple[str, ...], field_values: dict[str, bool | int]
     ) -> bool:
         """Enable one metadata provider after Arr finishes registering it."""
 

--- a/tests/integration/fixtures/radarr_client.py
+++ b/tests/integration/fixtures/radarr_client.py
@@ -76,17 +76,24 @@ class RadarrClient(ArrClient):
         return cast(dict[str, Any], response.json())
 
     def configure_metadata_settings(
-        self, use_movie_nfo: bool, movie_metadata_url: bool = False
+        self,
+        use_movie_nfo: bool,
+        movie_metadata_url: bool = False,
+        movie_metadata_language: int | None = None,
     ) -> bool:
         """Enable Kodi/Emby movie metadata and images for selected NFO mode."""
+        field_values: dict[str, bool | int] = {
+            "moviemetadata": True,
+            "moviemetadataurl": movie_metadata_url,
+            "movieimages": True,
+            "usemovienfo": use_movie_nfo,
+        }
+        if movie_metadata_language is not None:
+            field_values["moviemetadatalanguage"] = movie_metadata_language
+
         return self._configure_metadata_settings(
             provider_names=("kodi", "xbmc", "emby"),
-            field_values={
-                "moviemetadata": True,
-                "moviemetadataurl": movie_metadata_url,
-                "movieimages": True,
-                "usemovienfo": use_movie_nfo,
-            },
+            field_values=field_values,
         )
 
     def remove_movie(

--- a/tests/integration/test_radarr_integration.py
+++ b/tests/integration/test_radarr_integration.py
@@ -18,8 +18,6 @@ from tests.integration.test_helpers import (
 FIGHT_CLUB_TMDB_ID = 550
 AMELIE_TMDB_ID = 194
 AMELIE_FRENCH_TITLE = "Le Fabuleux Destin d'Amélie Poulain"
-HI_MOM_TMDB_ID = 758891
-HI_MOM_TRADITIONAL_TITLE = "你好\uff0c李煥英"
 
 
 def verify_movie_output(nfo_file: Path, image_files: list[Path]) -> None:
@@ -125,36 +123,6 @@ def test_radarr_french_movie_title_is_not_replaced_by_english_fallback(
             use_movie_nfo=True,
             movie_metadata_language=1,
         ), "Failed to reset Radarr English metadata"
-
-
-@pytest.mark.integration
-@pytest.mark.slow
-def test_radarr_prefers_traditional_chinese_movie_metadata(
-    temp_radarr_media_root: Path,
-    radarr_container: RadarrClient,
-) -> None:
-    """Rewrite a mainland Chinese movie with the configured Traditional Chinese data."""
-    assert radarr_container.configure_metadata_settings(use_movie_nfo=True), (
-        "Failed to configure Radarr movie metadata"
-    )
-
-    with MovieWithNfos(
-        radarr_container,
-        temp_radarr_media_root,
-        HI_MOM_TMDB_ID,
-        use_movie_nfo=True,
-    ) as (nfo_file, _):
-        with ServiceRunner(
-            temp_radarr_media_root,
-            {
-                "ENABLE_FILE_MONITOR": "false",
-                "ENABLE_IMAGE_REWRITE": "false",
-                "PREFERRED_LANGUAGES": "zh-TW,zh-CN",
-            },
-        ):
-            verify_translations([nfo_file], "zh", ["zh", "en"])
-
-        assert parse_nfo_content(nfo_file)["title"] == HI_MOM_TRADITIONAL_TITLE
 
 
 @pytest.mark.integration

--- a/tests/integration/test_radarr_integration.py
+++ b/tests/integration/test_radarr_integration.py
@@ -18,6 +18,8 @@ from tests.integration.test_helpers import (
 FIGHT_CLUB_TMDB_ID = 550
 AMELIE_TMDB_ID = 194
 AMELIE_FRENCH_TITLE = "Le Fabuleux Destin d'Amélie Poulain"
+HI_MOM_TMDB_ID = 758891
+HI_MOM_TRADITIONAL_TITLE = "你好\uff0c李煥英"
 
 
 def verify_movie_output(nfo_file: Path, image_files: list[Path]) -> None:
@@ -123,6 +125,36 @@ def test_radarr_french_movie_title_is_not_replaced_by_english_fallback(
             use_movie_nfo=True,
             movie_metadata_language=1,
         ), "Failed to reset Radarr English metadata"
+
+
+@pytest.mark.integration
+@pytest.mark.slow
+def test_radarr_prefers_traditional_chinese_movie_metadata(
+    temp_radarr_media_root: Path,
+    radarr_container: RadarrClient,
+) -> None:
+    """Rewrite a mainland Chinese movie with the configured Traditional Chinese data."""
+    assert radarr_container.configure_metadata_settings(use_movie_nfo=True), (
+        "Failed to configure Radarr movie metadata"
+    )
+
+    with MovieWithNfos(
+        radarr_container,
+        temp_radarr_media_root,
+        HI_MOM_TMDB_ID,
+        use_movie_nfo=True,
+    ) as (nfo_file, _):
+        with ServiceRunner(
+            temp_radarr_media_root,
+            {
+                "ENABLE_FILE_MONITOR": "false",
+                "ENABLE_IMAGE_REWRITE": "false",
+                "PREFERRED_LANGUAGES": "zh-TW,zh-CN",
+            },
+        ):
+            verify_translations([nfo_file], "zh", ["zh", "en"])
+
+        assert parse_nfo_content(nfo_file)["title"] == HI_MOM_TRADITIONAL_TITLE
 
 
 @pytest.mark.integration

--- a/tests/integration/test_radarr_integration.py
+++ b/tests/integration/test_radarr_integration.py
@@ -16,6 +16,8 @@ from tests.integration.test_helpers import (
 # Verified against TMDB /movie/550/images during test development: zh-CN has
 # poster and logo candidates. Missing upstream assets must fail this test.
 FIGHT_CLUB_TMDB_ID = 550
+AMELIE_TMDB_ID = 194
+AMELIE_FRENCH_TITLE = "Le Fabuleux Destin d'Amélie Poulain"
 
 
 def verify_movie_output(nfo_file: Path, image_files: list[Path]) -> None:
@@ -82,6 +84,45 @@ def test_radarr_movie_metadata_and_images(
             ServiceRunner(temp_radarr_media_root, service_config),
         ):
             verify_movie_output(nfo_file, image_files)
+
+
+@pytest.mark.integration
+@pytest.mark.slow
+def test_radarr_french_movie_title_is_not_replaced_by_english_fallback(
+    temp_radarr_media_root: Path,
+    radarr_container: RadarrClient,
+) -> None:
+    """Keep Radarr's French original title when English is a fallback language."""
+    assert radarr_container.configure_metadata_settings(
+        use_movie_nfo=True,
+        movie_metadata_language=2,
+    ), "Failed to configure Radarr French metadata"
+
+    try:
+        with MovieWithNfos(
+            radarr_container,
+            temp_radarr_media_root,
+            AMELIE_TMDB_ID,
+            use_movie_nfo=True,
+        ) as (nfo_file, _):
+            assert parse_nfo_content(nfo_file)["title"] == AMELIE_FRENCH_TITLE
+
+            with ServiceRunner(
+                temp_radarr_media_root,
+                {
+                    "ENABLE_FILE_MONITOR": "false",
+                    "ENABLE_IMAGE_REWRITE": "false",
+                    "PREFERRED_LANGUAGES": "fr-FR,en-US",
+                },
+            ):
+                verify_translations([nfo_file], "fr", ["fr", "en"])
+
+            assert parse_nfo_content(nfo_file)["title"] == AMELIE_FRENCH_TITLE
+    finally:
+        assert radarr_container.configure_metadata_settings(
+            use_movie_nfo=True,
+            movie_metadata_language=1,
+        ), "Failed to reset Radarr English metadata"
 
 
 @pytest.mark.integration

--- a/tests/integration/test_radarr_integration.py
+++ b/tests/integration/test_radarr_integration.py
@@ -18,6 +18,8 @@ from tests.integration.test_helpers import (
 FIGHT_CLUB_TMDB_ID = 550
 AMELIE_TMDB_ID = 194
 AMELIE_FRENCH_TITLE = "Le Fabuleux Destin d'Amélie Poulain"
+SHADOWS_EDGE_TMDB_ID = 1419406
+SHADOWS_EDGE_SIMPLIFIED_TITLE = "捕风追影"
 
 
 def verify_movie_output(nfo_file: Path, image_files: list[Path]) -> None:
@@ -88,36 +90,57 @@ def test_radarr_movie_metadata_and_images(
 
 @pytest.mark.integration
 @pytest.mark.slow
-def test_radarr_french_movie_title_is_not_replaced_by_english_fallback(
+@pytest.mark.parametrize(
+    ("tmdb_id", "metadata_language", "preferred_languages", "expected_title"),
+    [
+        (AMELIE_TMDB_ID, 2, "fr-FR,en-US", AMELIE_FRENCH_TITLE),
+        (
+            SHADOWS_EDGE_TMDB_ID,
+            10,
+            "zh-CN,zh-TW,en-US",
+            SHADOWS_EDGE_SIMPLIFIED_TITLE,
+        ),
+    ],
+    ids=["french-original", "mainland-chinese-original"],
+)
+def test_radarr_original_language_title_is_not_replaced_by_fallback(
     temp_radarr_media_root: Path,
     radarr_container: RadarrClient,
+    tmdb_id: int,
+    metadata_language: int,
+    preferred_languages: str,
+    expected_title: str,
 ) -> None:
-    """Keep Radarr's French original title when English is a fallback language."""
+    """Keep Radarr's original title when later fallbacks have another title."""
     assert radarr_container.configure_metadata_settings(
         use_movie_nfo=True,
-        movie_metadata_language=2,
-    ), "Failed to configure Radarr French metadata"
+        movie_metadata_language=metadata_language,
+    ), "Failed to configure Radarr localized metadata"
 
     try:
         with MovieWithNfos(
             radarr_container,
             temp_radarr_media_root,
-            AMELIE_TMDB_ID,
+            tmdb_id,
             use_movie_nfo=True,
         ) as (nfo_file, _):
-            assert parse_nfo_content(nfo_file)["title"] == AMELIE_FRENCH_TITLE
+            assert parse_nfo_content(nfo_file)["title"] == expected_title
 
             with ServiceRunner(
                 temp_radarr_media_root,
                 {
                     "ENABLE_FILE_MONITOR": "false",
                     "ENABLE_IMAGE_REWRITE": "false",
-                    "PREFERRED_LANGUAGES": "fr-FR,en-US",
+                    "PREFERRED_LANGUAGES": preferred_languages,
                 },
             ):
-                verify_translations([nfo_file], "fr", ["fr", "en"])
+                verify_translations(
+                    [nfo_file],
+                    preferred_languages.split("-", 1)[0],
+                    ["en", "fr", "zh"],
+                )
 
-            assert parse_nfo_content(nfo_file)["title"] == AMELIE_FRENCH_TITLE
+            assert parse_nfo_content(nfo_file)["title"] == expected_title
     finally:
         assert radarr_container.configure_metadata_settings(
             use_movie_nfo=True,

--- a/tests/integration/test_sonarr_integration.py
+++ b/tests/integration/test_sonarr_integration.py
@@ -205,7 +205,12 @@ def test_nfo_rewrite_disabled(
         # Translation fallback when preferred language has empty titles (issue #26).
         # Tests Chinese series "大明王朝1566" where some Chinese translations have
         # empty titles but valid descriptions, requiring fallback to complete.
-        (MING_DYNASTY_TVDB_ID, MING_DYNASTY_IMAGES, {}, "zh"),
+        (
+            MING_DYNASTY_TVDB_ID,
+            MING_DYNASTY_IMAGES,
+            {"PREFERRED_LANGUAGES": "zh-CN,en-US"},
+            "zh",
+        ),
         # External ID lookup workflow using TVDB ID to find TMDB ID (issue #29).
         # Tests "Every Treasure Tells a Story" series (TVDB: 364698 -> TMDB: 86965)
         # to verify TMDB ID resolution from TVDB ID when direct TMDB ID unavailable.

--- a/tests/unit/test_metadata_processor.py
+++ b/tests/unit/test_metadata_processor.py
@@ -588,6 +588,102 @@ def test_select_preferred_translation_partial_with_fallback(
     assert result.description.language == "fr-FR"
 
 
+def test_select_translation_uses_original_content_before_english_fallback(
+    test_data_dir: Path, mock_translator: Mock
+) -> None:
+    """Use original-language fields before lower-priority language fallbacks."""
+    settings = create_test_settings(test_data_dir, preferred_languages="fr-FR,en-US")
+    processor = MetadataProcessor(settings, mock_translator)
+    mock_translator.get_original_details.return_value = (
+        "fr",
+        "Le Fabuleux Destin d'Amélie Poulain",
+    )
+    mock_translator.get_original_translation.return_value = translated_content(
+        "Le Fabuleux Destin d'Amélie Poulain",
+        "Description originale",
+        "original",
+        "Une personne peut changer votre vie pour toujours.",
+    )
+
+    result = processor._select_translation_with_original_content(
+        {
+            "fr-FR": translated_content("", "Description française", "fr-FR"),
+            "en-US": translated_content(
+                "Amélie", "English description", "en-US", "English tagline"
+            ),
+        },
+        TmdbIds(tmdb_id=194, media_type="movie"),
+    )
+
+    assert result is not None
+    assert result.title.content == "Le Fabuleux Destin d'Amélie Poulain"
+    assert result.description.content == "Description française"
+    assert (
+        result.tagline.content == "Une personne peut changer votre vie pour toujours."
+    )
+
+
+def test_select_translation_skips_original_content_when_not_preferred(
+    test_data_dir: Path, mock_translator: Mock
+) -> None:
+    """Avoid an original-content request when its language cannot be selected."""
+    settings = create_test_settings(test_data_dir, preferred_languages="fr-FR,en-US")
+    processor = MetadataProcessor(settings, mock_translator)
+    mock_translator.get_original_details.return_value = ("ja", "千と千尋の神隠し")
+
+    result = processor._select_translation_with_original_content(
+        {
+            "fr-FR": translated_content(
+                "Le Voyage de Chihiro", "Description française", "fr-FR"
+            )
+        },
+        TmdbIds(tmdb_id=129, media_type="movie"),
+    )
+
+    assert result is not None
+    assert result.title.content == "Le Voyage de Chihiro"
+    mock_translator.get_original_translation.assert_not_called()
+
+
+def test_expanded_preferred_languages_adds_base_after_locale_variants(
+    test_data_dir: Path, mock_translator: Mock
+) -> None:
+    """Place an original-language candidate after its configured locales."""
+    settings = create_test_settings(
+        test_data_dir, preferred_languages="de-DE,fr-FR,fr-CA,en-US"
+    )
+    processor = MetadataProcessor(settings, mock_translator)
+
+    assert processor._expanded_preferred_languages() == [
+        "de-DE",
+        "de",
+        "fr-FR",
+        "fr-CA",
+        "fr",
+        "en-US",
+        "en",
+    ]
+
+
+def test_expanded_preferred_languages_deduplicates_non_adjacent_locales(
+    test_data_dir: Path, mock_translator: Mock
+) -> None:
+    """Keep each configured locale once before adding its base-language fallback."""
+    settings = create_test_settings(
+        test_data_dir,
+        preferred_languages="fr-FR,en-US,fr-FR,fr-CA,en-US",
+    )
+    processor = MetadataProcessor(settings, mock_translator)
+
+    assert processor._expanded_preferred_languages() == [
+        "fr-FR",
+        "en-US",
+        "en",
+        "fr-CA",
+        "fr",
+    ]
+
+
 def test_build_success_message_single_language(
     processor: MetadataProcessor,
 ) -> None:

--- a/tests/unit/test_rewrite_service.py
+++ b/tests/unit/test_rewrite_service.py
@@ -61,6 +61,10 @@ def test_service_start_stop(mock_logger: Mock, rewrite_service: RewriteService) 
         rewrite_service.start()
         mock_monitor_start.assert_called_once()
         mock_scanner_start.assert_called_once()
+        mock_logger.info.assert_any_call(
+            "Runtime preferred languages: "
+            f"{rewrite_service.metadata_processor.effective_preferred_languages}"
+        )
 
         # Test stop
         rewrite_service.stop()


### PR DESCRIPTION
## Background

TMDB translation entries can omit native-language fields. When a lower-priority language supplies the missing field, it replaces metadata already available in the media's original language.

## Behavior

Adds original-language metadata as a fallback candidate after configured regional variants of that language. Duplicate configured locales are removed from the runtime candidate order.

## Coverage

Covers French movie and Chinese series regressions with Radarr and Sonarr containers, multi-locale candidate ordering, and skipping the extra localized-details request when the original language is not preferred.

Closes #111