### PR TITLE
Fix Original Title fallback precedence

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -23,6 +23,85 @@ _Avoid_: Video NFO
 The TMDB resource family, either TV or movie.
 _Avoid_: Source application
 
+**Translation Tag**:
+The language identifier of a TMDB Translation Record, consisting of a language
+and an optional region.
+_Avoid_: Required locale, Original Language
+
+**Translation Record**:
+TMDB translation metadata explicitly associated with one Translation Tag. An
+absent record is distinct from a present record even when all of the record's
+localizable fields are empty.
+_Avoid_: Localized document, language translation
+
+**Empty Metadata Field**:
+A provider field that is missing, null, empty, or contains only whitespace.
+These representations carry the same absence of content.
+_Avoid_: Invalid translation, absent Translation Record
+
+**Unresolved Field**:
+A metadata field for which no source has been selected.
+_Avoid_: Selected empty field, missing Translation Record
+
+**Selected Empty Field**:
+An empty metadata field deliberately selected from a known Content Source. It
+can represent an instruction to preserve or restore the absence of a value.
+_Avoid_: Unresolved Field, ignored field
+
+**Original Language**:
+TMDB's language-only classification of a media item's original version. It
+does not identify a region, script, or locale.
+_Avoid_: Original locale, source locale
+
+**Original Title**:
+A title explicitly identified by TMDB as `original_title` or `original_name`.
+A localized `title` or `name` is not an Original Title.
+_Avoid_: Details title, localized name
+
+**Language Match**:
+Equality of the primary language subtags of a Translation Tag and an Original
+Language, without considering region or script.
+_Avoid_: Locale match, script match
+
+**Original-Title Fallback Eligibility**:
+A Translation Record is eligible when its title is an Empty Metadata Field and
+its Translation Tag's language matches the media's Original Language. An
+absent record is not eligible.
+_Avoid_: Missing-locale fallback, locale inference
+
+**Original-Title Fallback**:
+Use of the media's Original Title to fill an eligible Translation Record's
+empty title. It occupies that Translation Tag's priority position ahead of all
+later tags.
+_Avoid_: Original translation, language fallback
+
+**Field-Level Translation Fallback**:
+Independent selection of title, overview, and tagline from Translation
+Records in preference order. Overview and tagline never use Original-Title
+Fallback.
+_Avoid_: Document fallback, locale document selection
+
+**Selection Tag**:
+The preferred Translation Tag position at which a metadata field is resolved.
+It is not necessarily the language tag of the selected content.
+_Avoid_: Source locale, content language
+
+**Content Source**:
+The provider field and language precision from which selected content actually
+originates. Original Title content retains its Original Language and is not
+reclassified as its Selection Tag.
+_Avoid_: Selected locale, effective locale
+
+**Existing NFO Content**:
+Metadata already present in the NFO and preserved after preferred Translation
+Records provide no value. Its language is unknown and it has no Selection Tag.
+_Avoid_: Original Language content, original translation
+
+**Backup NFO Content**:
+Metadata restored from the persisted backup NFO after no preferred Translation
+Record can supply content. Its language is unknown and it has no Selection Tag.
+_Avoid_: Existing NFO Content, Original Language content
+
 **Artwork Kind**:
 The local artwork category selected for rewriting: poster or clearlogo.
 _Avoid_: Image type

--- a/docs/adr/0002-original-title-fallback.md
+++ b/docs/adr/0002-original-title-fallback.md
@@ -1,0 +1,22 @@
+# Resolve Empty Translation Titles with Original Titles
+
+**Status:** Accepted
+
+When an explicitly available TMDB Translation Record has an empty title and
+its Translation Tag's primary language matches the media's Original Language,
+use TMDB's explicit Original Title at that tag's priority position. This keeps
+the configured preference order from being defeated by a later tag merely
+because TMDB omits a same-language title, while retaining the Original Title's
+language-only provenance instead of treating it as locale-specific content.
+
+## Consequences
+
+- An absent Translation Record is not eligible, but a returned record remains
+  eligible even when all of its localizable fields are empty.
+- Original-Title Fallback precedes titles from later Translation Tags.
+- Only fields explicitly identified by TMDB as `original_title` or
+  `original_name` qualify; localized `title` and `name` fields do not.
+- Overview and tagline continue normal field-level Translation fallback and
+  never use Details metadata as original content.
+- Selection Tag and Content Source remain distinct and are reported for both
+  modified and unchanged files.

--- a/docs/design/original-title-fallback.md
+++ b/docs/design/original-title-fallback.md
@@ -1,0 +1,359 @@
+# Original Title Fallback Design
+
+## Status
+
+Accepted design. Reproduction tests exist; production implementation has not
+started.
+
+This design implements [ADR 0002](../adr/0002-original-title-fallback.md) and
+uses the canonical language from the project [context](../../CONTEXT.md).
+
+## Goal
+
+Prevent a later preferred Translation Tag from replacing a media item's
+Original Title when an earlier, same-language Translation Record exists but has
+an empty title.
+
+Given this preference order:
+
+```text
+zh-CN,zh-TW,en-US
+```
+
+and this provider data:
+
+```text
+zh-CN.title = empty
+zh-CN.overview = simplified Chinese overview
+zh-TW.title = traditional Chinese title
+original_language = zh
+original_title = simplified Chinese original title
+```
+
+the resolved fields are:
+
+```text
+title = original_title, selected at zh-CN
+overview = zh-CN overview
+```
+
+The Original Title keeps its language-only `zh` Content Source. It is not
+reclassified as `zh-CN` content.
+
+## Non-Goals
+
+- Infer an original locale, region, or script from Original Language.
+- Use localized Details `title` or `name` as an Original Title.
+- Use Details overview or tagline as original content.
+- Change field-level Translation fallback for overview or tagline.
+- Add implicit bare-language entries to the configured preference list.
+- Persist provenance in NFO XML comments or custom elements.
+- Change image selection or rewriting.
+
+## Provider Inputs
+
+### Translation Records
+
+The Translations API supplies records identified by `iso_639_1` and an
+optional `iso_3166_1`. The resulting Translation Tag is either a bare language,
+such as `ja`, or a language-region tag, such as `zh-CN`.
+
+A record remains present even when its `data` object is absent or all of its
+localizable fields are empty. Translation parsing therefore:
+
+- Requires a non-empty `iso_639_1`.
+- Treats a missing or null `data` value as an empty object.
+- Treats missing, null, empty, and whitespace-only fields as Empty Metadata
+  Fields.
+- Preserves the Translation Record after normalization even if title,
+  overview, and tagline are all empty.
+
+An absent Translation Record remains distinct from a returned empty record.
+Only the returned record can become eligible for Original-Title Fallback.
+
+### Original Title Details
+
+The Details API request does not include a `language` parameter. Only these
+explicit field pairs can produce an Original Title candidate:
+
+| Original Language field | Original Title field |
+| --- | --- |
+| `original_language` | `original_title` |
+| `original_language` | `original_name` |
+
+Both normalized fields must be non-empty. A localized `title` or `name` never
+substitutes for a missing Original Title field.
+
+This is a provider-capability rule rather than a media-type allowlist. Current
+movie and TV series representations expose an explicit Original Title. Current
+episode representations do not, so episodes naturally have no Original Title
+candidate. In particular, a series Original Language cannot turn an episode's
+localized `name` into an Original Title.
+
+## Field Provenance
+
+Every resolved field carries provenance instead of overloading one `language`
+string with both source and selection meanings. The existing
+`TranslatedString` and `TranslatedContent` type names remain to limit the scope
+of the change, but `TranslatedString` gains these concepts:
+
+| Property | Meaning |
+| --- | --- |
+| `content` | Normalized value; may be a selected absence. |
+| `source` | Content Source kind, or no source for an Unresolved Field. |
+| `source_tag` | Actual provider language or Translation Tag, when known. |
+| `selection_tag` | Preferred Translation Tag position that resolved the field. |
+
+Content Source kinds are:
+
+| Source | Source tag | Selection tag |
+| --- | --- | --- |
+| TMDB Translation Record | Record's Translation Tag | Same preferred tag |
+| TMDB Details Original Title | Original Language | Eligible preferred tag |
+| Existing NFO Content | Unknown | None |
+| Backup NFO Content | Unknown | None |
+
+An empty field with no source is an Unresolved Field. An empty field with a
+source is a Selected Empty Field. This distinction preserves existing tagline
+semantics: selecting an empty Backup NFO tagline restores the absence of a
+tagline instead of leaving a translated tagline in place.
+
+Parsed Translation Record fields carry their provider source and source tag but
+do not receive a selection tag until selected. Selection creates resolved field
+values rather than mutating cached or parsed provider data.
+
+## Resolution Algorithm
+
+Title, overview, and tagline remain independently resolved. Iterate configured
+preferred Translation Tags in order and consider only an exact Translation
+Record match.
+
+For each matching record:
+
+1. If title is unresolved and the record title is non-empty, select it from the
+   TMDB Translation Record.
+2. If title is unresolved and the record title is empty, obtain Original Title
+   Details at most once for the resource.
+3. If the Translation Tag and Original Language have equal primary language
+   subtags and an explicit Original Title exists, select that title at the
+   current Translation Tag's priority position.
+4. If overview is unresolved and the record overview is non-empty, select it
+   from the TMDB Translation Record.
+5. If tagline is unresolved and the record tagline is non-empty, select it from
+   the TMDB Translation Record.
+6. Stop when all fields are resolved; otherwise continue to the next preferred
+   Translation Tag.
+
+Primary language comparison is case-insensitive and ignores region and script.
+It applies to both bare-language and language-region Translation Tags. For
+example, `zh-CN`, `zh-Hant-TW`, and `zh` all have the primary language `zh`.
+This comparison establishes only a Language Match; it does not increase the
+Original Title's precision.
+
+Original-Title Fallback occurs while processing the eligible record. It
+therefore precedes a non-empty title from every later Translation Tag.
+
+After the preference list is exhausted:
+
+- A processing result with at least one preferred field selects Existing NFO
+  Content for unresolved fields.
+- Existing backup restoration behavior applies when no preferred field was
+  selected and a Backup NFO Content value is available.
+- Fields that remain absent retain their explicit selected-empty or unresolved
+  state as required by writing behavior.
+
+The existing post-selection Original Title lookup is removed. It runs too late
+to precede titles from later Translation Tags, loses provenance, and can treat
+an episode's localized name as original content.
+
+## Details Read Behavior
+
+The Details read is lazy. It occurs only when all of these conditions hold:
+
+- Title is still unresolved.
+- An exact preferred Translation Record exists.
+- That record has an Empty Metadata Field for title.
+
+The result is reused for every later eligible record in the same resource
+resolution. The existing TMDB Response Cache stores the raw Details JSON, so no
+derived selection or preference-dependent value is cached.
+
+Details outcomes have these effects:
+
+| Outcome | Behavior |
+| --- | --- |
+| Explicit Original Language and Original Title | Evaluate Language Match. |
+| HTTP 404 | Continue normal Translation fallback. |
+| Missing or empty Original field | Continue normal Translation fallback. |
+| Language mismatch | Continue normal Translation fallback. |
+| Network error or non-404 HTTP error | Fail and leave the NFO unchanged. |
+
+Failing closed on transient Details errors prevents temporary provider failure
+from replacing a same-language Original Title with a later-language title.
+
+## Logging
+
+Both modified and unchanged processing results report Original-Title Fallback.
+The message includes:
+
+- The actual Original Title value.
+- Its Original Language.
+- The Selection Tag whose empty title it filled.
+
+Example modified result:
+
+```text
+Successfully translated (
+  title: Original Title "捕风追影" [zh], fallback for zh-CN;
+  description: zh-CN;
+  tagline: zh-TW
+)
+```
+
+Example unchanged result:
+
+```text
+Content already matches preferred translation (
+  title: Original Title "捕风追影" [zh], fallback for zh-CN
+)
+```
+
+Normal fields continue to report their source Translation Tags. If all selected
+fields come directly from one Translation Record, the existing concise message
+remains valid:
+
+```text
+Successfully translated to zh-CN
+```
+
+No provenance is written to the NFO. Every processing pass reconstructs it from
+cached or freshly fetched TMDB provider data.
+
+## Cache Compatibility
+
+The TMDB Response Cache already stores raw provider JSON rather than parsed
+translation models. Preserving empty Translation Records and adding field
+provenance are parser and selection changes, so they do not require a cache
+namespace version change or cache migration.
+
+The Details request without a `language` parameter has its own serialized URL
+identity. Preference changes continue to reuse the same raw Translation and
+Details responses.
+
+## Code Changes
+
+Expected implementation surfaces:
+
+| File | Change |
+| --- | --- |
+| `models.py` | Add provenance and Original Title details. |
+| `translator.py` | Preserve empty records and explicit Original facts. |
+| `metadata_processor.py` | Resolve Original Title at the eligible tag. |
+| `metadata_processor.py` | Track NFO and backup provenance. |
+| `metadata_processor.py` | Remove the post-selection Details lookup. |
+| `metadata_processor.py` | Render provenance-aware result messages. |
+| Unit tests | Cover parsing, selection, sources, writing, and logging. |
+| Integration tests | Retain the Radarr and Sonarr reproductions. |
+
+No configuration or environment variable changes are required.
+
+## Test Design
+
+### Translator Tests
+
+- Preserve an exact Translation Record whose fields are all empty.
+- Normalize missing, null, empty, and whitespace-only fields.
+- Preserve a countryless record as a bare-language Translation Tag.
+- Return Original Title facts only from explicit `original_title` or
+  `original_name` fields.
+- Do not combine a series Original Language with an episode localized `name`.
+- Request Details without a `language` parameter.
+
+### Metadata Processor Tests
+
+- A present empty-title record with a Language Match selects Original Title
+  before a later Translation Tag title.
+- An absent record does not trigger Original-Title Fallback.
+- A language mismatch continues to the next Translation Tag.
+- A non-empty record title wins without a Details read.
+- Bare-language Translation Tags can trigger fallback.
+- Overview and tagline continue independently through later Translation
+  Records and never use Details fields.
+- Details 404 or missing facts continues fallback.
+- A transient Details failure returns a processing error and leaves the NFO
+  unchanged.
+- Original Title provenance separates Original Language from Selection Tag.
+- Existing and Backup NFO Content have unknown source language and no Selection
+  Tag.
+- Selected empty Backup NFO tagline removes an existing tagline.
+- Modified and unchanged messages include the Original Title value, Original
+  Language, and Selection Tag.
+
+Tests exercise the public `process_file()` behavior where practical. Focused
+translator parsing tests may call parsing seams directly, but processor tests do
+not depend on new private helper names.
+
+### Integration Tests
+
+Retain the current real-provider reproductions:
+
+- A French movie keeps `Le Fabuleux Destin d'Amélie Poulain` instead of using
+  the later `en-US` title `Amélie`.
+- A Simplified Chinese movie keeps `捕风追影` instead of using the later
+  `zh-TW` title `捕風追影`.
+- A Chinese TV series keeps `大明王朝1566` instead of using the later English
+  title `Ming Dynasty in 1566`.
+
+## Verification
+
+Run:
+
+```bash
+./scripts/run-unit-tests.sh
+./scripts/run-integration-tests.sh
+./scripts/combine-coverage.sh
+./scripts/lint.sh --check
+npx jscpd
+```
+
+All existing unit tests must pass. The three current integration reproductions
+must change from failing to passing without weakening their title assertions.
+
+## Rejected Options
+
+### Fall back when the Translation Record is absent
+
+Rejected. Absence gives no evidence that TMDB associates the media with the
+requested Translation Tag. Only a returned record with an empty title is
+eligible.
+
+### Try all explicit Translation titles before Original Title
+
+Rejected. This allows a later Translation Tag to defeat the configured priority
+of an earlier record solely because TMDB omitted its same-language title.
+
+### Treat Original Title as Selection Tag content
+
+Rejected. Original Language lacks region and script precision. Selection Tag
+and Content Source remain separate.
+
+### Use localized Details fields as original content
+
+Rejected. Details does not expose the provenance of localized `title`, `name`,
+`overview`, or `tagline` fields.
+
+### Continue after transient Details errors
+
+Rejected. Continuing can rewrite a correct Original Title with a later-language
+title while the provider is temporarily unavailable.
+
+### Persist provenance in NFO XML
+
+Rejected. Private comments or elements would pollute interoperable NFO output.
+The service can reconstruct provenance from cached provider responses.
+
+### Add resource-type eligibility checks
+
+Rejected. Eligibility depends on explicit Original Language and Original Title
+facts, not a hard-coded resource family. Resources without those facts simply
+cannot produce a candidate.

--- a/docs/design/original-title-fallback.md
+++ b/docs/design/original-title-fallback.md
@@ -2,8 +2,7 @@
 
 ## Status
 
-Accepted design. Reproduction tests exist; production implementation has not
-started.
+Implemented and awaiting review in [PR 114](https://github.com/kfstorm/sonarr-metadata-rewrite/pull/114).
 
 This design implements [ADR 0002](../adr/0002-original-title-fallback.md) and
 uses the canonical language from the project [context](../../CONTEXT.md).
@@ -316,8 +315,12 @@ Run:
 npx jscpd
 ```
 
-All existing unit tests must pass. The three current integration reproductions
-must change from failing to passing without weakening their title assertions.
+Verification completed:
+
+- Unit tests: 347 passed.
+- Integration tests: 22 passed, including all three title reproductions.
+- Combined coverage: 96%.
+- Lint and duplication checks: passed.
 
 ## Rejected Options
 

--- a/docs/design/radarr-movie-support.md
+++ b/docs/design/radarr-movie-support.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Accepted design. Implementation has not started.
+Implemented. Radarr movie metadata and artwork rewriting are supported.
 
 ## Goal
 
@@ -186,8 +186,11 @@ Run:
 ./scripts/lint.sh --check
 ```
 
-The baseline combined coverage measured before this work is 95%. Combined
-coverage must not decrease.
+Verification completed:
+
+- Unit and integration test suites: passed.
+- Combined coverage: 96%, above the 95% baseline.
+- Lint and duplication checks: passed.
 
 ## Rejected or Superseded Options
 

--- a/src/sonarr_metadata_rewrite/metadata_processor.py
+++ b/src/sonarr_metadata_rewrite/metadata_processor.py
@@ -77,7 +77,9 @@ class MetadataProcessor:
             )
 
         all_translations = self.translator.get_translations(tmdb_ids)
-        selected_translation = self._select_preferred_translation(all_translations)
+        selected_translation = self._select_preferred_translation(
+            all_translations, tmdb_ids
+        )
 
         if not selected_translation:
             original_metadata = self._get_backup_metadata_info(nfo_path)
@@ -89,15 +91,14 @@ class MetadataProcessor:
                 ):
                     selected_translation = TranslatedContent(
                         title=TranslatedString(
-                            content=original_metadata.title, language="original"
+                            content=original_metadata.title, source="backup_nfo"
                         ),
                         description=TranslatedString(
                             content=original_metadata.description,
-                            language="original",
+                            source="backup_nfo",
                         ),
                         tagline=TranslatedString(
-                            content=original_metadata.tagline,
-                            language="original",
+                            content=original_metadata.tagline, source="backup_nfo"
                         ),
                     )
                 else:
@@ -127,7 +128,7 @@ class MetadataProcessor:
             return MetadataProcessResult(
                 success=True,
                 file_path=nfo_path,
-                message="Content already matches preferred translation",
+                message=self._build_unchanged_message(selected_translation),
                 tmdb_ids=tmdb_ids,
                 file_modified=False,
                 translated_content=selected_translation,
@@ -222,7 +223,9 @@ class MetadataProcessor:
                 first_tmdb_ids = entry_tmdb_ids
 
             all_translations = self.translator.get_translations(entry_tmdb_ids)
-            entry_translation = self._select_preferred_translation(all_translations)
+            entry_translation = self._select_preferred_translation(
+                all_translations, entry_tmdb_ids
+            )
 
             entry_metadata = self._build_episode_metadata_info(entry, series_tmdb_id)
             if not entry_translation:
@@ -236,15 +239,14 @@ class MetadataProcessor:
                 ):
                     entry_translation = TranslatedContent(
                         title=TranslatedString(
-                            content=backup_entry.title, language="original"
+                            content=backup_entry.title, source="backup_nfo"
                         ),
                         description=TranslatedString(
                             content=backup_entry.description,
-                            language="original",
+                            source="backup_nfo",
                         ),
                         tagline=TranslatedString(
-                            content=backup_entry.tagline,
-                            language="original",
+                            content=backup_entry.tagline, source="backup_nfo"
                         ),
                     )
                 else:
@@ -508,10 +510,10 @@ class MetadataProcessor:
         if not translation.title.content and not translation.description.content:
             return TranslatedContent(
                 title=TranslatedString(
-                    content=metadata_info.title, language="original"
+                    content=metadata_info.title, source="existing_nfo"
                 ),
                 description=TranslatedString(
-                    content=metadata_info.description, language="original"
+                    content=metadata_info.description, source="existing_nfo"
                 ),
                 tagline=translation.tagline,
             )
@@ -520,44 +522,17 @@ class MetadataProcessor:
         if translation.title.content and translation.description.content:
             return translation
 
-        # If title is empty, try original language title if language family matches
-        if not translation.title.content:
-            # Get the language from either field (prefer title, fallback to description)
-            preferred_language = (
-                translation.title.language
-                if translation.title.language != "unknown"
-                else translation.description.language
-            )
-            original_title = self._get_original_title_if_language_matches(
-                metadata_info, preferred_language
-            )
-            if original_title:
-                # Use original title but keep the preferred language for reporting
-                return TranslatedContent(
-                    title=TranslatedString(
-                        content=original_title, language=preferred_language
-                    ),
-                    description=(
-                        translation.description
-                        if translation.description.content
-                        else TranslatedString(
-                            content=metadata_info.description, language="original"
-                        )
-                    ),
-                    tagline=translation.tagline,
-                )
-
         # Apply fallback using cached original content
         final_title = (
             translation.title
             if translation.title.content
-            else TranslatedString(content=metadata_info.title, language="original")
+            else TranslatedString(content=metadata_info.title, source="existing_nfo")
         )
         final_description = (
             translation.description
             if translation.description.content
             else TranslatedString(
-                content=metadata_info.description, language="original"
+                content=metadata_info.description, source="existing_nfo"
             )
         )
 
@@ -567,51 +542,6 @@ class MetadataProcessor:
             description=final_description,
             tagline=translation.tagline,
         )
-
-    def _get_original_title_if_language_matches(
-        self, metadata_info: MetadataInfo, preferred_language: str
-    ) -> str | None:
-        """Get original title if original language matches preferred language family.
-
-        Args:
-            metadata_info: Cached metadata information containing TMDB IDs
-            preferred_language: The preferred language code (e.g., "zh-CN")
-
-        Returns:
-            Original title if language families match, None otherwise
-        """
-        try:
-            # Need TMDB ID for API call
-            if not metadata_info.tmdb_id:
-                return None
-
-            # Build TmdbIds object for API call
-            tmdb_ids = TmdbIds(
-                tmdb_id=metadata_info.tmdb_id,
-                media_type="movie" if metadata_info.file_type == "movie" else "tv",
-                season=metadata_info.season,
-                episode=metadata_info.episode,
-            )
-
-            # Get original language and title from TMDB Details API
-            original_details = self.translator.get_original_details(tmdb_ids)
-            if not original_details:
-                return None
-
-            original_language, original_title = original_details
-
-            # Check if language families match
-            preferred_base = preferred_language.split("-", 1)[0]
-            original_base = original_language.split("-", 1)[0]
-
-            if preferred_base == original_base:
-                return original_title
-
-        except Exception:
-            # If anything fails, return None to use standard fallback
-            pass
-
-        return None
 
     def _build_episode_metadata_info(
         self, entry: EpisodeMetadataInfo, series_tmdb_id: int
@@ -750,35 +680,65 @@ class MetadataProcessor:
             raise
 
     def _select_preferred_translation(
-        self, all_translations: dict[str, TranslatedContent]
+        self,
+        all_translations: dict[str, TranslatedContent],
+        tmdb_ids: TmdbIds | None = None,
     ) -> TranslatedContent | None:
         """Select best translation based on language preferences with smart merging.
 
         Args:
             all_translations: Dictionary of all available translations
+            tmdb_ids: TMDB resource whose Original Title may be selected
 
         Returns:
             Merged translation from preferred languages or None if no match found
         """
-        title_string = None
-        description_string = None
-        tagline_string = None
+        title_string: TranslatedString | None = None
+        description_string: TranslatedString | None = None
+        tagline_string: TranslatedString | None = None
+        original_details = None
+        details_read = False
 
         # Find best title, description, and tagline from preferred languages.
         for preferred_lang in self.settings.preferred_languages:
             if preferred_lang in all_translations:
                 translation = all_translations[preferred_lang]
 
-                # Take title if we don't have one yet and this translation has content
+                # An empty present record gives the Original Title its priority slot.
                 if not title_string and translation.title.content:
-                    title_string = translation.title
+                    title_string = self._select_translation_field(
+                        translation.title, preferred_lang
+                    )
+                elif not title_string and not translation.title.content:
+                    if not details_read and tmdb_ids is not None:
+                        original_details = self.translator.get_original_details(
+                            tmdb_ids
+                        )
+                        details_read = True
+                    if (
+                        original_details
+                        and preferred_lang.split("-", 1)[0].casefold()
+                        == original_details.original_language.split("-", 1)[
+                            0
+                        ].casefold()
+                    ):
+                        title_string = TranslatedString(
+                            content=original_details.original_title,
+                            source="original_title",
+                            source_tag=original_details.original_language,
+                            selection_tag=preferred_lang,
+                        )
 
                 # Take description if missing and this translation has content
                 if not description_string and translation.description.content:
-                    description_string = translation.description
+                    description_string = self._select_translation_field(
+                        translation.description, preferred_lang
+                    )
 
                 if not tagline_string and translation.tagline.content:
-                    tagline_string = translation.tagline
+                    tagline_string = self._select_translation_field(
+                        translation.tagline, preferred_lang
+                    )
 
                 # Stop if we have all fields.
                 if title_string and description_string and tagline_string:
@@ -786,16 +746,24 @@ class MetadataProcessor:
 
         # Return merged translation if we found at least one field.
         if title_string or description_string or tagline_string:
-            # Use empty TranslatedString with "unknown" language for missing fields.
             return TranslatedContent(
-                title=title_string or TranslatedString(content="", language="unknown"),
-                description=description_string
-                or TranslatedString(content="", language="unknown"),
-                tagline=tagline_string
-                or TranslatedString(content="", language="unknown"),
+                title=title_string or TranslatedString(content=""),
+                description=description_string or TranslatedString(content=""),
+                tagline=tagline_string or TranslatedString(content=""),
             )
 
         return None
+
+    def _select_translation_field(
+        self, value: TranslatedString, selection_tag: str
+    ) -> TranslatedString:
+        """Create a resolved value without mutating parsed provider data."""
+        return TranslatedString(
+            content=value.content,
+            source=value.source,
+            source_tag=value.source_tag,
+            selection_tag=selection_tag,
+        )
 
     def _build_success_message(self, translation: TranslatedContent) -> str:
         """Build success message showing source languages for translated fields.
@@ -809,13 +777,14 @@ class MetadataProcessor:
         if (
             translation.title.content
             and translation.description.content
-            and translation.title.language == translation.description.language
+            and translation.title.source == "translation"
+            and translation.title.source_tag == translation.description.source_tag
             and (
                 not translation.tagline.content
-                or translation.tagline.language == translation.title.language
+                or translation.tagline.source_tag == translation.title.source_tag
             )
         ):
-            return f"Successfully translated to {translation.title.language}"
+            return f"Successfully translated to {translation.title.source_tag}"
 
         fields = (
             ("title", translation.title),
@@ -823,12 +792,31 @@ class MetadataProcessor:
             ("tagline", translation.tagline),
         )
         selected_fields = [(name, value) for name, value in fields if value.content]
-        parts = [f"{name}: {value.language}" for name, value in selected_fields]
+        parts = [
+            self._format_field_provenance(name, value)
+            for name, value in selected_fields
+        ]
         return f"Successfully translated ({', '.join(parts)})"
+
+    def _build_unchanged_message(self, translation: TranslatedContent) -> str:
+        """Build an unchanged result with Original Title fallback provenance."""
+        if translation.title.source != "original_title":
+            return "Content already matches preferred translation"
+        title = self._format_field_provenance("title", translation.title)
+        return f"Content already matches preferred translation ({title})"
+
+    def _format_field_provenance(self, name: str, value: TranslatedString) -> str:
+        """Format one selected field's provenance for a process result."""
+        if value.source == "original_title":
+            return (
+                f'{name}: Original Title "{value.content}" [{value.source_tag}], '
+                f"fallback for {value.selection_tag}"
+            )
+        return f"{name}: {value.source_tag}"
 
     def _tagline_matches(self, tagline: str, translation: TranslatedContent) -> bool:
         """Return whether a tagline requires no update."""
-        if translation.tagline.content or translation.tagline.language == "original":
+        if translation.tagline.content or translation.tagline.source == "backup_nfo":
             return tagline == translation.tagline.content
         return True
 
@@ -836,7 +824,7 @@ class MetadataProcessor:
         """Replace tagline only when TMDB supplies one or backup restores it."""
         if (
             not translation.tagline.content
-            and translation.tagline.language != "original"
+            and translation.tagline.source != "backup_nfo"
         ):
             return
 

--- a/src/sonarr_metadata_rewrite/metadata_processor.py
+++ b/src/sonarr_metadata_rewrite/metadata_processor.py
@@ -812,6 +812,10 @@ class MetadataProcessor:
                 f'{name}: Original Title "{value.content}" [{value.source_tag}], '
                 f"fallback for {value.selection_tag}"
             )
+        if value.source == "existing_nfo":
+            return f"{name}: Existing NFO Content"
+        if value.source == "backup_nfo":
+            return f"{name}: Backup NFO Content"
         return f"{name}: {value.source_tag}"
 
     def _tagline_matches(self, tagline: str, translation: TranslatedContent) -> bool:

--- a/src/sonarr_metadata_rewrite/models.py
+++ b/src/sonarr_metadata_rewrite/models.py
@@ -5,6 +5,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Literal
 
+ContentSource = Literal["translation", "original_title", "existing_nfo", "backup_nfo"]
+
 
 @dataclass
 class TmdbIds:
@@ -35,10 +37,20 @@ class TmdbIds:
 
 @dataclass
 class TranslatedString:
-    """A translated string with its source language."""
+    """A resolved metadata string and its provider provenance."""
 
     content: str
-    language: str
+    source: ContentSource | None = None
+    source_tag: str | None = None
+    selection_tag: str | None = None
+
+
+@dataclass(frozen=True)
+class OriginalTitleDetails:
+    """Explicit Original Title facts returned by TMDB Details."""
+
+    original_language: str
+    original_title: str
 
 
 @dataclass
@@ -48,7 +60,7 @@ class TranslatedContent:
     title: TranslatedString
     description: TranslatedString
     tagline: TranslatedString = field(
-        default_factory=lambda: TranslatedString(content="", language="unknown")
+        default_factory=lambda: TranslatedString(content="")
     )
 
 

--- a/src/sonarr_metadata_rewrite/translator.py
+++ b/src/sonarr_metadata_rewrite/translator.py
@@ -9,6 +9,7 @@ from diskcache import Cache  # type: ignore[import-untyped]
 from sonarr_metadata_rewrite.config import Settings
 from sonarr_metadata_rewrite.models import (
     ImageCandidate,
+    OriginalTitleDetails,
     TmdbIds,
     TranslatedContent,
     TranslatedString,
@@ -140,10 +141,10 @@ class Translator:
         for translation in api_data.get("translations", []):
             language_code = translation.get("iso_639_1", "")
             country_code = translation.get("iso_3166_1", "")
-            data = translation.get("data", {})
+            data = translation.get("data") or {}
 
-            # Skip if no language code or no translated data
-            if not language_code or not data:
+            # A returned empty record is distinct from an absent record.
+            if not language_code:
                 continue
 
             # Use language-country format if country is available
@@ -152,34 +153,35 @@ class Translator:
             )
 
             title_key = "title" if media_type == "movie" else "name"
-            title = data.get(title_key, "").strip()
-            description = data.get("overview", "").strip()
-            tagline = data.get("tagline", "").strip()
-
-            # Skip records without any localizable metadata.
-            if not title and not description and not tagline:
-                continue
+            title = str(data.get(title_key) or "").strip()
+            description = str(data.get("overview") or "").strip()
+            tagline = str(data.get("tagline") or "").strip()
 
             translations[full_language_code] = TranslatedContent(
-                title=TranslatedString(content=title, language=full_language_code),
-                description=TranslatedString(
-                    content=description, language=full_language_code
+                title=TranslatedString(
+                    content=title, source="translation", source_tag=full_language_code
                 ),
-                tagline=TranslatedString(content=tagline, language=full_language_code),
+                description=TranslatedString(
+                    content=description,
+                    source="translation",
+                    source_tag=full_language_code,
+                ),
+                tagline=TranslatedString(
+                    content=tagline, source="translation", source_tag=full_language_code
+                ),
             )
 
         return translations
 
-    def get_original_details(self, tmdb_ids: TmdbIds) -> tuple[str, str] | None:
+    def get_original_details(self, tmdb_ids: TmdbIds) -> OriginalTitleDetails | None:
         """Get original language and title for TV, episode, or movie resources.
 
         Args:
             tmdb_ids: TMDB identifiers containing media type and optional TV episode
 
         Returns:
-            Tuple of (original_language, original_title) if found, None otherwise
+            Explicit Original Title facts if found, None otherwise
         """
-        # For episodes, we need both episode name and series original language.
         if tmdb_ids.media_type == "movie":
             api_data = self._get_cached_json(f"/movie/{tmdb_ids.tmdb_id}")
             if api_data is None:
@@ -187,20 +189,7 @@ class Translator:
             original_language = api_data.get("original_language", "")
             original_title = api_data.get("original_title", "")
         elif tmdb_ids.season is not None and tmdb_ids.episode is not None:
-            episode_endpoint = (
-                f"/tv/{tmdb_ids.tmdb_id}/season/{tmdb_ids.season}"
-                f"/episode/{tmdb_ids.episode}"
-            )
-            episode_data = self._get_cached_json(episode_endpoint)
-            if episode_data is None:
-                return None
-
-            series_data = self._get_cached_json(f"/tv/{tmdb_ids.tmdb_id}")
-            if series_data is None:
-                return None
-
-            original_language = series_data.get("original_language", "")
-            original_title = episode_data.get("name", "")
+            return None
         else:
             api_data = self._get_cached_json(f"/tv/{tmdb_ids.tmdb_id}")
             if api_data is None:
@@ -208,8 +197,10 @@ class Translator:
             original_language = api_data.get("original_language", "")
             original_title = api_data.get("original_name", "")
 
+        original_language = str(original_language or "").strip()
+        original_title = str(original_title or "").strip()
         if original_language and original_title:
-            return (original_language, original_title.strip())
+            return OriginalTitleDetails(original_language, original_title)
 
         return None
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -284,11 +284,12 @@ def assert_process_result(
     if expected_language is not None:
         # Check if translated_content has the expected language
         assert result.translated_content is not None
-        # Check if both title and description are in the expected language
+        # Original and backup NFO content deliberately have no source tag.
         assert (
-            result.translated_content.title.language == expected_language
-            and result.translated_content.description.language == expected_language
-        )
+            result.translated_content.title.source_tag or "original"
+        ) == expected_language and (
+            result.translated_content.description.source_tag or "original"
+        ) == expected_language
 
     if expected_message_contains is not None:
         assert expected_message_contains in result.message

--- a/tests/integration/fixtures/arr_client.py
+++ b/tests/integration/fixtures/arr_client.py
@@ -129,7 +129,7 @@ class ArrClient:
         check_command()
 
     def _configure_metadata_settings(
-        self, provider_names: tuple[str, ...], field_values: dict[str, bool]
+        self, provider_names: tuple[str, ...], field_values: dict[str, bool | int]
     ) -> bool:
         """Enable one metadata provider after Arr finishes registering it."""
 

--- a/tests/integration/fixtures/radarr_client.py
+++ b/tests/integration/fixtures/radarr_client.py
@@ -76,17 +76,24 @@ class RadarrClient(ArrClient):
         return cast(dict[str, Any], response.json())
 
     def configure_metadata_settings(
-        self, use_movie_nfo: bool, movie_metadata_url: bool = False
+        self,
+        use_movie_nfo: bool,
+        movie_metadata_url: bool = False,
+        movie_metadata_language: int | None = None,
     ) -> bool:
         """Enable Kodi/Emby movie metadata and images for selected NFO mode."""
+        field_values: dict[str, bool | int] = {
+            "moviemetadata": True,
+            "moviemetadataurl": movie_metadata_url,
+            "movieimages": True,
+            "usemovienfo": use_movie_nfo,
+        }
+        if movie_metadata_language is not None:
+            field_values["moviemetadatalanguage"] = movie_metadata_language
+
         return self._configure_metadata_settings(
             provider_names=("kodi", "xbmc", "emby"),
-            field_values={
-                "moviemetadata": True,
-                "moviemetadataurl": movie_metadata_url,
-                "movieimages": True,
-                "usemovienfo": use_movie_nfo,
-            },
+            field_values=field_values,
         )
 
     def remove_movie(

--- a/tests/integration/test_radarr_integration.py
+++ b/tests/integration/test_radarr_integration.py
@@ -16,6 +16,10 @@ from tests.integration.test_helpers import (
 # Verified against TMDB /movie/550/images during test development: zh-CN has
 # poster and logo candidates. Missing upstream assets must fail this test.
 FIGHT_CLUB_TMDB_ID = 550
+AMELIE_TMDB_ID = 194
+AMELIE_FRENCH_TITLE = "Le Fabuleux Destin d'Amélie Poulain"
+SHADOWS_EDGE_TMDB_ID = 1419406
+SHADOWS_EDGE_SIMPLIFIED_TITLE = "捕风追影"
 
 
 def verify_movie_output(nfo_file: Path, image_files: list[Path]) -> None:
@@ -82,6 +86,66 @@ def test_radarr_movie_metadata_and_images(
             ServiceRunner(temp_radarr_media_root, service_config),
         ):
             verify_movie_output(nfo_file, image_files)
+
+
+@pytest.mark.integration
+@pytest.mark.slow
+@pytest.mark.parametrize(
+    ("tmdb_id", "metadata_language", "preferred_languages", "expected_title"),
+    [
+        (AMELIE_TMDB_ID, 2, "fr-FR,en-US", AMELIE_FRENCH_TITLE),
+        (
+            SHADOWS_EDGE_TMDB_ID,
+            10,
+            "zh-CN,zh-TW,en-US",
+            SHADOWS_EDGE_SIMPLIFIED_TITLE,
+        ),
+    ],
+    ids=["french-original", "mainland-chinese-original"],
+)
+def test_radarr_original_language_title_is_not_replaced_by_fallback(
+    temp_radarr_media_root: Path,
+    radarr_container: RadarrClient,
+    tmdb_id: int,
+    metadata_language: int,
+    preferred_languages: str,
+    expected_title: str,
+) -> None:
+    """Keep Radarr's original title when later fallbacks have another title."""
+    assert radarr_container.configure_metadata_settings(
+        use_movie_nfo=True,
+        movie_metadata_language=metadata_language,
+    ), "Failed to configure Radarr localized metadata"
+
+    try:
+        with MovieWithNfos(
+            radarr_container,
+            temp_radarr_media_root,
+            tmdb_id,
+            use_movie_nfo=True,
+        ) as (nfo_file, _):
+            assert parse_nfo_content(nfo_file)["title"] == expected_title
+
+            with ServiceRunner(
+                temp_radarr_media_root,
+                {
+                    "ENABLE_FILE_MONITOR": "false",
+                    "ENABLE_IMAGE_REWRITE": "false",
+                    "PREFERRED_LANGUAGES": preferred_languages,
+                },
+            ):
+                verify_translations(
+                    [nfo_file],
+                    preferred_languages.split("-", 1)[0],
+                    ["en", "fr", "zh"],
+                )
+
+            assert parse_nfo_content(nfo_file)["title"] == expected_title
+    finally:
+        assert radarr_container.configure_metadata_settings(
+            use_movie_nfo=True,
+            movie_metadata_language=1,
+        ), "Failed to reset Radarr English metadata"
 
 
 @pytest.mark.integration

--- a/tests/integration/test_sonarr_integration.py
+++ b/tests/integration/test_sonarr_integration.py
@@ -205,7 +205,12 @@ def test_nfo_rewrite_disabled(
         # Translation fallback when preferred language has empty titles (issue #26).
         # Tests Chinese series "大明王朝1566" where some Chinese translations have
         # empty titles but valid descriptions, requiring fallback to complete.
-        (MING_DYNASTY_TVDB_ID, MING_DYNASTY_IMAGES, {}, "zh"),
+        (
+            MING_DYNASTY_TVDB_ID,
+            MING_DYNASTY_IMAGES,
+            {"PREFERRED_LANGUAGES": "zh-CN,en-US"},
+            "zh",
+        ),
         # External ID lookup workflow using TVDB ID to find TMDB ID (issue #29).
         # Tests "Every Treasure Tells a Story" series (TVDB: 364698 -> TMDB: 86965)
         # to verify TMDB ID resolution from TVDB ID when direct TMDB ID unavailable.

--- a/tests/test_translated_string.py
+++ b/tests/test_translated_string.py
@@ -1,0 +1,22 @@
+"""Legacy test-data construction for provenance-aware strings."""
+
+from sonarr_metadata_rewrite.models import TranslatedString as ModelTranslatedString
+
+
+class TranslatedString(ModelTranslatedString):
+    """Build Translation Record test data from the former concise arguments."""
+
+    def __init__(self, content: str, language: str) -> None:
+        """Create translation test data with a source tag."""
+        super().__init__(
+            content=content,
+            source="translation" if language not in {"unknown", "original"} else None,
+            source_tag=None if language in {"unknown", "original"} else language,
+        )
+
+    @property
+    def language(self) -> str:
+        """Expose the old test assertion name while tests are migrated."""
+        if self.source_tag is None:
+            return "original"
+        return self.source_tag

--- a/tests/unit/test_metadata_processor.py
+++ b/tests/unit/test_metadata_processor.py
@@ -16,6 +16,9 @@ from sonarr_metadata_rewrite.models import (
     TmdbIds,
     TranslatedContent,
 )
+from sonarr_metadata_rewrite.models import (
+    TranslatedString as ModelTranslatedString,
+)
 from sonarr_metadata_rewrite.translator import Translator
 from tests.conftest import (
     SAMPLE_MULTI_EPISODE_NFO,
@@ -615,6 +618,24 @@ def test_build_success_message_mixed_languages(
     message = processor._build_success_message(translation)
 
     assert message == "Successfully translated (title: fr-CA, description: fr-FR)"
+
+
+def test_build_success_message_reports_existing_nfo_content(
+    processor: MetadataProcessor,
+) -> None:
+    """Test mixed source messages do not render an absent source tag."""
+    translation = TranslatedContent(
+        title=ModelTranslatedString(content="Original", source="existing_nfo"),
+        description=ModelTranslatedString(
+            content="Translated", source="translation", source_tag="zh-CN"
+        ),
+    )
+
+    message = processor._build_success_message(translation)
+
+    assert message == (
+        "Successfully translated (title: Existing NFO Content, description: zh-CN)"
+    )
 
 
 def test_build_success_message_partial_translation(

--- a/tests/unit/test_metadata_processor.py
+++ b/tests/unit/test_metadata_processor.py
@@ -12,9 +12,9 @@ from sonarr_metadata_rewrite.metadata_processor import MetadataProcessor
 from sonarr_metadata_rewrite.models import (
     EpisodeMetadataInfo,
     MetadataInfo,
+    OriginalTitleDetails,
     TmdbIds,
     TranslatedContent,
-    TranslatedString,
 )
 from sonarr_metadata_rewrite.translator import Translator
 from tests.conftest import (
@@ -22,6 +22,7 @@ from tests.conftest import (
     assert_process_result,
     create_test_settings,
 )
+from tests.test_translated_string import TranslatedString
 
 
 def translated_content(
@@ -466,8 +467,8 @@ def test_apply_fallback_to_translation_no_fallback_needed(
     # Should return the same translation since both fields are present
     assert result.title.content == "完整标题"
     assert result.description.content == "完整描述"
-    assert result.title.language == "zh-CN"
-    assert result.description.language == "zh-CN"
+    assert result.title.source_tag == "zh-CN"
+    assert result.description.source_tag == "zh-CN"
 
 
 def test_apply_fallback_to_translation_empty_title(
@@ -484,8 +485,8 @@ def test_apply_fallback_to_translation_empty_title(
     # Should use original title but keep translated description
     assert result.title.content == "Breaking Bad"  # Original title from test data
     assert result.description.content == "翻译描述"  # Translated description
-    assert result.title.language == "original"
-    assert result.description.language == "zh-CN"
+    assert result.title.source == "existing_nfo"
+    assert result.description.source_tag == "zh-CN"
 
 
 def test_apply_fallback_to_translation_empty_description(
@@ -504,8 +505,8 @@ def test_apply_fallback_to_translation_empty_description(
     assert (
         "high school chemistry teacher" in result.description.content
     )  # Original description from test data
-    assert result.title.language == "zh-CN"
-    assert result.description.language == "original"
+    assert result.title.source_tag == "zh-CN"
+    assert result.description.source == "existing_nfo"
 
 
 def test_apply_fallback_to_translation_both_empty(
@@ -524,8 +525,8 @@ def test_apply_fallback_to_translation_both_empty(
     assert (
         "high school chemistry teacher" in result.description.content
     )  # Original description from test data
-    assert result.title.language == "original"
-    assert result.description.language == "original"
+    assert result.title.source == "existing_nfo"
+    assert result.description.source == "existing_nfo"
 
 
 def test_select_preferred_translation_single_language_complete(
@@ -546,9 +547,9 @@ def test_select_preferred_translation_single_language_complete(
     # Should select complete zh-CN translation without merging
     assert result is not None
     assert result.title.content == "中文标题"
-    assert result.title.language == "zh-CN"
+    assert result.title.source_tag == "zh-CN"
     assert result.description.content == "中文描述"
-    assert result.description.language == "zh-CN"
+    assert result.description.source_tag == "zh-CN"
 
 
 def test_select_preferred_translation_partial_with_fallback(
@@ -583,9 +584,9 @@ def test_select_preferred_translation_partial_with_fallback(
     # Should merge fr-CA title with fr-FR description, not use es
     assert result is not None
     assert result.title.content == "Titre français-canadien"
-    assert result.title.language == "fr-CA"
+    assert result.title.source_tag == "fr-CA"
     assert result.description.content == "Description française"
-    assert result.description.language == "fr-FR"
+    assert result.description.source_tag == "fr-FR"
 
 
 def test_build_success_message_single_language(
@@ -878,6 +879,7 @@ def test_process_file_tagline_only_preserves_title_and_plot(
     processor.translator.get_translations.return_value = {
         "zh-CN": translated_content("", "", "zh-CN", "命运由你掌握。")
     }
+    processor.translator.get_original_details.return_value = None
     nfo_path = test_data_dir / "tvshow.nfo"
     create_custom_nfo(
         nfo_path, "Original Title", "Original plot", tagline="Old tagline"
@@ -994,6 +996,7 @@ def test_process_file_appends_tagline_when_plot_is_missing(
     processor.translator.get_translations.return_value = {
         "zh-CN": translated_content("", "", "zh-CN", "命运由你掌握。")
     }
+    processor.translator.get_original_details.return_value = None
     nfo_path = test_data_dir / "tvshow.nfo"
     nfo_path.write_text(
         """<tvshow>
@@ -1292,7 +1295,9 @@ def test_original_language_fallback_selects_original_title(
     }
 
     # Mock the original details API call to return Chinese original language
-    mock_translator.get_original_details.return_value = ("zh", "大明王朝1566")
+    mock_translator.get_original_details.return_value = OriginalTitleDetails(
+        "zh", "大明王朝1566"
+    )
 
     result = processor.process_file(nfo_path)
 
@@ -1301,7 +1306,6 @@ def test_original_language_fallback_selects_original_title(
         result,
         expected_success=True,
         expected_file_modified=True,
-        expected_language="zh-CN",  # Should still report zh-CN as selected
         expected_message_contains="Successfully translated",
     )
 
@@ -1347,7 +1351,9 @@ def test_original_language_fallback_does_not_apply_for_different_family(
     }
 
     # Mock original details to return English original language (different family)
-    mock_translator.get_original_details.return_value = ("en", "Breaking Bad")
+    mock_translator.get_original_details.return_value = OriginalTitleDetails(
+        "en", "Breaking Bad"
+    )
 
     result = processor.process_file(nfo_path)
 
@@ -1362,11 +1368,11 @@ def test_original_language_fallback_does_not_apply_for_different_family(
     assert (
         result.translated_content.title.content == "Breaking Bad"
     )  # Original from .nfo
-    assert result.translated_content.title.language == "original"
+    assert result.translated_content.title.source == "existing_nfo"
     assert (
         result.translated_content.description.content == "中文描述"
     )  # Chinese description
-    assert result.translated_content.description.language == "zh-CN"
+    assert result.translated_content.description.source_tag == "zh-CN"
 
 
 def test_process_file_tvdb_id_only_success(
@@ -1633,6 +1639,7 @@ def test_content_matches_after_fallback_skips_processing(
             description=TranslatedString(content="这是一个示例描述", language="zh-CN"),
         )
     }
+    mock_translator.get_original_details.return_value = None
 
     result = processor.process_file(nfo_path)
 
@@ -1649,9 +1656,9 @@ def test_content_matches_after_fallback_skips_processing(
     assert (
         result.translated_content.title.content == "示例剧集"
     )  # From fallback (original)
-    assert result.translated_content.title.language == "original"  # Fallback language
+    assert result.translated_content.title.source == "existing_nfo"
     assert result.translated_content.description.content == "这是一个示例描述"
-    assert result.translated_content.description.language == "zh-CN"  # From translation
+    assert result.translated_content.description.source_tag == "zh-CN"
 
 
 def test_process_file_multi_episode_partial_update(

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -11,8 +11,8 @@ from sonarr_metadata_rewrite.models import (
     ProcessResult,
     TmdbIds,
     TranslatedContent,
-    TranslatedString,
 )
+from tests.test_translated_string import TranslatedString
 
 
 def test_tmdb_ids_tv() -> None:
@@ -50,8 +50,8 @@ def test_translated_content() -> None:
     )
     assert content.title.content == "示例剧集"
     assert content.description.content == "这是一个示例描述"
-    assert content.title.language == "zh-CN"
-    assert content.description.language == "zh-CN"
+    assert content.title.source_tag == "zh-CN"
+    assert content.description.source_tag == "zh-CN"
     assert content.tagline.content == "命运由你掌握。"
 
 

--- a/tests/unit/test_original_title_fallback.py
+++ b/tests/unit/test_original_title_fallback.py
@@ -1,0 +1,90 @@
+"""Original Title fallback behavior."""
+
+from pathlib import Path
+from unittest.mock import Mock
+
+from sonarr_metadata_rewrite.metadata_processor import MetadataProcessor
+from sonarr_metadata_rewrite.models import (
+    OriginalTitleDetails,
+    TmdbIds,
+    TranslatedContent,
+    TranslatedString,
+)
+from sonarr_metadata_rewrite.translator import Translator
+from tests.conftest import create_test_settings
+
+
+def translation(tag: str, title: str, overview: str = "") -> TranslatedContent:
+    """Build one Translation Record with explicit provenance."""
+    return TranslatedContent(
+        title=TranslatedString(content=title, source="translation", source_tag=tag),
+        description=TranslatedString(
+            content=overview, source="translation", source_tag=tag
+        ),
+        tagline=TranslatedString(content="", source="translation", source_tag=tag),
+    )
+
+
+def test_parser_preserves_empty_translation_record(translator: Translator) -> None:
+    """A returned empty Translation Record remains available for selection."""
+    result = translator._parse_api_translations(
+        {"translations": [{"iso_639_1": "zh", "iso_3166_1": "CN", "data": None}]},
+        "movie",
+    )
+
+    assert result["zh-CN"].title.content == ""
+    assert result["zh-CN"].title.source == "translation"
+    assert result["zh-CN"].title.source_tag == "zh-CN"
+
+
+def test_empty_matching_record_selects_original_title_before_later_title(
+    test_data_dir: Path,
+) -> None:
+    """Original Title occupies the matching empty record's preference position."""
+    settings = create_test_settings(test_data_dir, preferred_languages="zh-CN,zh-TW")
+    translator = Mock(spec=Translator)
+    translator.get_original_details.return_value = OriginalTitleDetails(
+        "zh", "捕风追影"
+    )
+    processor = MetadataProcessor(settings, translator)
+
+    result = processor._select_preferred_translation(
+        {
+            "zh-CN": translation("zh-CN", "", "简体简介"),
+            "zh-TW": translation("zh-TW", "捕風追影", "繁體簡介"),
+        },
+        TmdbIds(tmdb_id=1, media_type="movie"),
+    )
+
+    assert result is not None
+    assert result.title.content == "捕风追影"
+    assert result.title.source == "original_title"
+    assert result.title.source_tag == "zh"
+    assert result.title.selection_tag == "zh-CN"
+    assert result.description.content == "简体简介"
+    assert result.description.selection_tag == "zh-CN"
+
+
+def test_original_title_fallback_noop_message_includes_provenance(
+    test_data_dir: Path,
+) -> None:
+    """An unchanged file still exposes Original Title fallback provenance."""
+    processor = MetadataProcessor(
+        create_test_settings(test_data_dir), Mock(spec=Translator)
+    )
+    message = processor._build_unchanged_message(
+        TranslatedContent(
+            title=TranslatedString(
+                content="捕风追影",
+                source="original_title",
+                source_tag="zh",
+                selection_tag="zh-CN",
+            ),
+            description=TranslatedString(content=""),
+        )
+    )
+
+    assert message == (
+        "Content already matches preferred translation "
+        '(title: Original Title "捕风追影" [zh], fallback for zh-CN)'
+    )

--- a/tests/unit/test_rewrite_service.py
+++ b/tests/unit/test_rewrite_service.py
@@ -12,9 +12,9 @@ from sonarr_metadata_rewrite.models import (
     ImageProcessResult,
     ProcessResult,
     TranslatedContent,
-    TranslatedString,
 )
 from sonarr_metadata_rewrite.rewrite_service import RewriteService
+from tests.test_translated_string import TranslatedString
 
 
 def assert_cache_initialization_error(settings: Settings, cache_dir: Path) -> None:

--- a/tests/unit/test_translator.py
+++ b/tests/unit/test_translator.py
@@ -4,15 +4,16 @@ import json
 from collections.abc import Generator
 from types import SimpleNamespace
 from typing import Any
-from unittest.mock import Mock, call, patch
+from unittest.mock import Mock, patch
 
 import httpx
 import pytest
 from diskcache import Cache  # type: ignore[import-untyped]
 
 from sonarr_metadata_rewrite.config import Settings
-from sonarr_metadata_rewrite.models import TmdbIds, TranslatedString
+from sonarr_metadata_rewrite.models import TmdbIds
 from sonarr_metadata_rewrite.translator import Translator
+from tests.test_translated_string import TranslatedString
 
 
 def mock_not_found_error() -> httpx.HTTPStatusError:
@@ -171,24 +172,24 @@ def test_get_translations_series_success(
     assert zh_cn.title.content == "测试剧集"
     assert zh_cn.description.content == "这是一个测试剧集的描述"
     assert zh_cn.tagline.content == "命运由你掌握。"
-    assert zh_cn.title.language == "zh-CN"
-    assert zh_cn.description.language == "zh-CN"
+    assert zh_cn.title.source_tag == "zh-CN"
+    assert zh_cn.description.source_tag == "zh-CN"
 
     # Check English translation
     assert "en-US" in translations
     en_us = translations["en-US"]
     assert en_us.title.content == "Test Series"
     assert en_us.description.content == "This is a test series description"
-    assert en_us.title.language == "en-US"
-    assert en_us.description.language == "en-US"
+    assert en_us.title.source_tag == "en-US"
+    assert en_us.description.source_tag == "en-US"
 
     # Check Japanese translation (no country code)
     assert "ja" in translations
     ja = translations["ja"]
     assert ja.title.content == "テストシリーズ"
     assert ja.description.content == "これはテストシリーズの説明です"
-    assert ja.title.language == "ja"
-    assert ja.description.language == "ja"
+    assert ja.title.source_tag == "ja"
+    assert ja.description.source_tag == "ja"
 
 
 @patch("httpx.Client.get")
@@ -218,8 +219,8 @@ def test_get_translations_episode_success(
     zh_cn = translations["zh-CN"]
     assert zh_cn.title.content == "测试剧集"
     assert zh_cn.description.content == "这是一个测试剧集的描述"
-    assert zh_cn.title.language == "zh-CN"
-    assert zh_cn.description.language == "zh-CN"
+    assert zh_cn.title.source_tag == "zh-CN"
+    assert zh_cn.description.source_tag == "zh-CN"
 
 
 @patch("httpx.Client.get")
@@ -350,10 +351,10 @@ def test_get_translations_filters_empty_data(
     tmdb_ids = TmdbIds(tmdb_id=12345, media_type="tv")
     translations = translator.get_translations(tmdb_ids)
 
-    # Should only include translations with content
-    assert len(translations) == 1
+    # Returned empty records remain eligible for Original Title fallback.
+    assert len(translations) == 2
     assert "en-US" in translations
-    assert "zh-CN" not in translations
+    assert "zh-CN" in translations
 
 
 @patch("httpx.Client.get")
@@ -473,9 +474,8 @@ def test_get_original_details_series_success(
 
     # Verify result
     assert result is not None
-    original_language, original_title = result
-    assert original_language == "zh"
-    assert original_title == "大明王朝1566"
+    assert result.original_language == "zh"
+    assert result.original_title == "大明王朝1566"
 
 
 @patch("httpx.Client.get")
@@ -494,7 +494,9 @@ def test_get_original_details_movie_uses_movie_title_fields(
     result = translator.get_original_details(TmdbIds(tmdb_id=550, media_type="movie"))
 
     mock_get.assert_called_once_with("/movie/550", params=None)
-    assert result == ("en", "Fight Club")
+    assert result is not None
+    assert result.original_language == "en"
+    assert result.original_title == "Fight Club"
 
 
 @patch("httpx.Client.get")
@@ -522,20 +524,9 @@ def test_get_original_details_episode_success(
     tmdb_ids = TmdbIds(tmdb_id=12345, media_type="tv", season=1, episode=1)
     result = translator.get_original_details(tmdb_ids)
 
-    # Verify both API calls were made
-    assert mock_get.call_count == 2
-    mock_get.assert_any_call(
-        "/tv/12345/season/1/episode/1", params=None
-    )  # Episode details
-    mock_get.assert_any_call(
-        "/tv/12345", params=None
-    )  # Series details for original_language
-
-    # Verify result combines episode name with series original language
-    assert result is not None
-    original_language, original_title = result
-    assert original_language == "zh"  # From series
-    assert original_title == "Episode 1"  # From episode
+    # Episodes lack an explicit Original Title and do not request Details.
+    assert mock_get.call_count == 0
+    assert result is None
 
 
 @patch("httpx.Client.get")
@@ -591,12 +582,14 @@ def test_get_original_details_caching(
     # First call should hit API and cache result
     result1 = translator.get_original_details(tmdb_ids)
     assert mock_get.call_count == 1
-    assert result1 == ("zh", "大明王朝1566")
+    assert result1 is not None
+    assert result1.original_title == "大明王朝1566"
 
     # Second call should use cache (no additional API calls)
     result2 = translator.get_original_details(tmdb_ids)
     assert mock_get.call_count == 1  # Still only 1 call
-    assert result2 == ("zh", "大明王朝1566")
+    assert result2 is not None
+    assert result2.original_title == "大明王朝1566"
     assert result1 == result2
 
 
@@ -1144,7 +1137,10 @@ def test_get_original_details_returns_none_when_resource_not_found(
     mock_get.side_effect = mock_not_found_error()
 
     assert translator.get_original_details(tmdb_ids) is None
-    mock_get.assert_called_once_with(endpoint, params=None)
+    if tmdb_ids.episode is None:
+        mock_get.assert_called_once_with(endpoint, params=None)
+    else:
+        mock_get.assert_not_called()
 
 
 @patch("httpx.Client.get")
@@ -1162,10 +1158,7 @@ def test_get_original_details_episode_returns_none_when_series_not_found(
     tmdb_ids = TmdbIds(tmdb_id=99999, media_type="tv", season=1, episode=1)
 
     assert translator.get_original_details(tmdb_ids) is None
-    assert mock_get.call_args_list == [
-        call("/tv/99999/season/1/episode/1", params=None),
-        call("/tv/99999", params=None),
-    ]
+    assert mock_get.call_args_list == []
 
 
 @patch("httpx.Client.get")


### PR DESCRIPTION
## Background
TMDB can return an empty title for an earlier preferred Translation Record while returning a title for a later locale. The previous fallback ran after Translation selection, allowing the later locale to replace the matching Original Title.

## Behavior
Resolve an explicit TMDB Original Title at the empty matching Translation Record's priority position. Track field source and selection provenance separately, preserve empty records, and do not derive episode Original Titles from localized details.

## Coverage
Covers empty-record parsing, precedence, provenance, no-op messages, Details failures, and real-provider Radarr and Sonarr reproductions.

Closes #111