### PR TITLE
Skip unsupported NFO root tags

### DIFF
--- a/src/sonarr_metadata_rewrite/file_utils.py
+++ b/src/sonarr_metadata_rewrite/file_utils.py
@@ -20,6 +20,14 @@ TRAILING_SCRAPER_URLS_RE = re.compile(
 )
 
 
+class UnsupportedNfoRootError(ValueError):
+    """Raised when a valid NFO has a root tag the service does not translate."""
+
+    def __init__(self, root_tag: str) -> None:
+        """Initialize the error for the unsupported root tag."""
+        super().__init__(f"Unsupported NFO root tag: {root_tag}")
+
+
 def parse_image_info(basename: str) -> tuple[str, int | None]:
     """Parse image basename to determine kind and season number.
 
@@ -200,6 +208,9 @@ def _parse_nfo_documents(nfo_path: Path) -> MetadataInfo:
         metadata = _extract_episode_metadata(wrapped_root)
         metadata.trailing_scraper_urls = scraper_urls
         return metadata
+
+    if len(wrapped_root) == 1:
+        raise UnsupportedNfoRootError(wrapped_root[0].tag)
 
     raise ET.ParseError("Unsupported NFO root structure")
 

--- a/src/sonarr_metadata_rewrite/metadata_processor.py
+++ b/src/sonarr_metadata_rewrite/metadata_processor.py
@@ -7,7 +7,11 @@ from typing import Literal
 
 from sonarr_metadata_rewrite.backup_utils import create_backup, get_backup_path
 from sonarr_metadata_rewrite.config import Settings
-from sonarr_metadata_rewrite.file_utils import extract_metadata_info, is_nfo_file
+from sonarr_metadata_rewrite.file_utils import (
+    UnsupportedNfoRootError,
+    extract_metadata_info,
+    is_nfo_file,
+)
 from sonarr_metadata_rewrite.models import (
     EpisodeMetadataInfo,
     MetadataInfo,
@@ -48,6 +52,14 @@ class MetadataProcessor:
 
             return self._process_single_metadata_file(nfo_path, metadata_info)
 
+        except UnsupportedNfoRootError as e:
+            return MetadataProcessResult(
+                success=True,
+                file_path=nfo_path,
+                message=f"{e}; skipped",
+                file_modified=False,
+                translated_content=None,
+            )
         except Exception as e:
             return MetadataProcessResult(
                 success=False,

--- a/tests/unit/test_file_utils.py
+++ b/tests/unit/test_file_utils.py
@@ -3,15 +3,18 @@
 import tempfile
 import xml.etree.ElementTree as ET
 from pathlib import Path
+from unittest.mock import Mock, patch
 
 import pytest
 
 from sonarr_metadata_rewrite.file_utils import (
+    UnsupportedNfoRootError,
     extract_metadata_info,
     find_root_dir_for_file,
     find_target_files,
     is_nfo_file,
     is_rewritable_image,
+    parse_nfo_with_retry,
 )
 
 
@@ -464,6 +467,37 @@ class TestExtractMetadataInfo:
 
         with pytest.raises(ET.ParseError, match="Unsupported NFO root structure"):
             extract_metadata_info(nfo_path)
+
+    def test_extract_metadata_info_rejects_unsupported_single_root_tag(
+        self, test_data_dir: Path
+    ) -> None:
+        """Reject a valid NFO root tag the service does not translate."""
+        nfo_path = test_data_dir / "season.nfo"
+        nfo_path.write_text(
+            "<season><title>Season 1</title><seasonnumber>1</seasonnumber></season>",
+            encoding="utf-8",
+        )
+
+        with pytest.raises(UnsupportedNfoRootError, match="root tag: season"):
+            extract_metadata_info(nfo_path)
+
+    def test_parse_nfo_does_not_retry_unsupported_root_tag(
+        self, test_data_dir: Path
+    ) -> None:
+        """Do not retry valid XML that uses an unsupported root tag."""
+        nfo_path = test_data_dir / "season.nfo"
+        parse_documents = Mock(side_effect=UnsupportedNfoRootError("season"))
+
+        with (
+            patch(
+                "sonarr_metadata_rewrite.file_utils._parse_nfo_documents",
+                parse_documents,
+            ),
+            pytest.raises(UnsupportedNfoRootError, match="root tag: season"),
+        ):
+            parse_nfo_with_retry(nfo_path)
+
+        parse_documents.assert_called_once_with(nfo_path)
 
 
 class TestFindRootDirForFile:

--- a/tests/unit/test_metadata_processor.py
+++ b/tests/unit/test_metadata_processor.py
@@ -412,6 +412,26 @@ def test_process_file_nonexistent_file(
     )
 
 
+def test_process_file_skips_unsupported_nfo_root(
+    processor: MetadataProcessor,
+    mock_translator: Mock,
+    test_data_dir: Path,
+) -> None:
+    """Skip valid NFO files whose root tag has no translation support."""
+    nfo_path = test_data_dir / "season.nfo"
+    content = "<season><title>Season 1</title><seasonnumber>1</seasonnumber></season>"
+    nfo_path.write_text(content, encoding="utf-8")
+
+    result = processor.process_file(nfo_path)
+
+    assert result.success is True
+    assert result.message == "Unsupported NFO root tag: season; skipped"
+    assert result.exception is None
+    assert result.file_modified is False
+    assert nfo_path.read_text(encoding="utf-8") == content
+    mock_translator.get_translations.assert_not_called()
+
+
 def test_process_file_no_preferred_translation(
     processor: MetadataProcessor,
     mock_translator: Mock,


### PR DESCRIPTION
## Background

Valid NFO documents with an unsupported root tag, such as Jellyfin `season.nfo`, are currently retried and reported as processing errors.

## Behavior

- Classify valid, single-document NFOs with unsupported root tags separately from malformed XML.
- Skip those files without retrying, modifying files, calling TMDB, or producing an error traceback.
- Keep malformed XML, XML with invalid outer text, and unsupported mixed-root documents on the existing error path.

Refs #112