### PR TITLE
fix: fail early for a missing TMDB API key

### DIFF
--- a/src/sonarr_metadata_rewrite/config.py
+++ b/src/sonarr_metadata_rewrite/config.py
@@ -2,9 +2,9 @@
 
 import os
 from pathlib import Path
-from typing import Any
+from typing import Any, Self
 
-from pydantic import Field, ValidationError, field_validator
+from pydantic import Field, ValidationError, field_validator, model_validator
 from pydantic_settings import (
     BaseSettings,
     PydanticBaseSettingsSource,
@@ -93,7 +93,20 @@ class Settings(BaseSettings):
         )
 
     # TMDB API
-    tmdb_api_key: str = Field(description="TMDB API key for translation requests")
+    tmdb_api_key: str = Field(
+        default="",
+        description="TMDB API key for translation requests",
+    )
+
+    @field_validator("tmdb_api_key", mode="before")
+    @classmethod
+    def normalize_tmdb_api_key(cls, v: object) -> str:
+        """Normalize an omitted, empty, or whitespace-only TMDB API key."""
+        if v is None:
+            return ""
+        if not isinstance(v, str):
+            raise ValueError("tmdb_api_key must be a string")
+        return v.strip()
 
     # Directory monitoring
     rewrite_root_dirs: list[Path] = Field(
@@ -188,6 +201,13 @@ class Settings(BaseSettings):
         if v not in ["rewrite", "rollback"]:
             raise ValueError("service_mode must be either 'rewrite' or 'rollback'")
         return v
+
+    @model_validator(mode="after")
+    def validate_mode_requirements(self) -> Self:
+        """Validate configuration requirements that depend on service mode."""
+        if self.service_mode == "rewrite" and not self.tmdb_api_key:
+            raise ValueError("TMDB_API_KEY is required when SERVICE_MODE=rewrite")
+        return self
 
 
 def get_settings() -> Settings:

--- a/src/sonarr_metadata_rewrite/main.py
+++ b/src/sonarr_metadata_rewrite/main.py
@@ -40,7 +40,10 @@ def cli() -> None:
         sys.exit(1)
 
     click.echo("🚀 Starting Sonarr and Radarr Metadata Rewrite...")
-    click.echo(f"✅ TMDB API key loaded (ending in ...{settings.tmdb_api_key[-4:]})")
+    if settings.tmdb_api_key:
+        click.echo(
+            f"✅ TMDB API key loaded (ending in ...{settings.tmdb_api_key[-4:]})"
+        )
     for root_dir in settings.rewrite_root_dirs:
         click.echo(f"📁 Monitoring directory: {root_dir}")
     click.echo(f"🌍 Preferred languages: {settings.preferred_languages}")

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -71,7 +71,10 @@ class TestCli:
             "SERVICE_MODE": "rewrite",
         }
 
-        with patch.dict(os.environ, env_vars, clear=True):
+        with (
+            runner.isolated_filesystem(),
+            patch.dict(os.environ, env_vars, clear=True),
+        ):
             result = runner.invoke(cli)
 
         assert result.exit_code == 1

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -63,16 +63,20 @@ class TestCli:
             assert "🔧 Service mode: rewrite" in result.output
 
     def test_cli_missing_api_key(self) -> None:
-        """Test CLI with missing TMDB API key."""
+        """Test rewrite mode with only the TMDB API key missing."""
         runner = CliRunner()
+        env_vars = {
+            "REWRITE_ROOT_DIR": "/tmp/test",
+            "PREFERRED_LANGUAGES": "zh-CN",
+            "SERVICE_MODE": "rewrite",
+        }
 
-        with patch.dict(os.environ, {}, clear=True):
+        with patch.dict(os.environ, env_vars, clear=True):
             result = runner.invoke(cli)
 
         assert result.exit_code == 1
-        # Check for the actual pydantic validation error message
         assert "❌ Configuration error:" in result.output
-        assert "Field required" in result.output
+        assert "TMDB_API_KEY is required when SERVICE_MODE=rewrite" in result.output
 
     def test_cli_version(self) -> None:
         """Test CLI version option."""

--- a/tests/unit/test_tmdb_api_key_validation.py
+++ b/tests/unit/test_tmdb_api_key_validation.py
@@ -30,13 +30,18 @@ def test_rewrite_mode_rejects_empty_tmdb_api_key(
         )
 
 
-def test_rewrite_mode_rejects_missing_tmdb_api_key(tmp_path: Path) -> None:
+def test_rewrite_mode_rejects_missing_tmdb_api_key(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Rewrite mode rejects an omitted TMDB API key."""
+    monkeypatch.delenv("TMDB_API_KEY", raising=False)
+
     with pytest.raises(
         ValidationError,
         match="TMDB_API_KEY is required when SERVICE_MODE=rewrite",
     ):
         Settings(
+            _env_file=None,
             rewrite_root_dirs=[tmp_path],
             preferred_languages=["zh-CN"],
             service_mode="rewrite",
@@ -59,9 +64,14 @@ def test_rollback_mode_allows_empty_tmdb_api_key(
     assert settings.tmdb_api_key == ""
 
 
-def test_rollback_mode_allows_missing_tmdb_api_key(tmp_path: Path) -> None:
+def test_rollback_mode_allows_missing_tmdb_api_key(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Rollback mode allows the TMDB API key to be omitted."""
+    monkeypatch.delenv("TMDB_API_KEY", raising=False)
+
     settings = Settings(
+        _env_file=None,
         rewrite_root_dirs=[tmp_path],
         preferred_languages=["zh-CN"],
         service_mode="rollback",
@@ -101,6 +111,7 @@ def test_cli_rollback_mode_runs_without_tmdb_api_key(tmp_path: Path) -> None:
     }
 
     with (
+        runner.isolated_filesystem(),
         patch.dict(os.environ, env_vars, clear=True),
         patch("sonarr_metadata_rewrite.main.RollbackService") as rollback_service,
     ):

--- a/tests/unit/test_tmdb_api_key_validation.py
+++ b/tests/unit/test_tmdb_api_key_validation.py
@@ -30,14 +30,38 @@ def test_rewrite_mode_rejects_empty_tmdb_api_key(
         )
 
 
-@pytest.mark.parametrize("api_key", [None, "", " ", "\t"])
-def test_rollback_mode_allows_missing_tmdb_api_key(
-    api_key: str | None,
+def test_rewrite_mode_rejects_missing_tmdb_api_key(tmp_path: Path) -> None:
+    """Rewrite mode rejects an omitted TMDB API key."""
+    with pytest.raises(
+        ValidationError,
+        match="TMDB_API_KEY is required when SERVICE_MODE=rewrite",
+    ):
+        Settings(
+            rewrite_root_dirs=[tmp_path],
+            preferred_languages=["zh-CN"],
+            service_mode="rewrite",
+        )
+
+
+@pytest.mark.parametrize("api_key", ["", " ", "\t"])
+def test_rollback_mode_allows_empty_tmdb_api_key(
+    api_key: str,
     tmp_path: Path,
 ) -> None:
-    """Rollback mode does not access TMDB and must not require its API key."""
+    """Rollback mode does not access TMDB and allows an empty API key."""
     settings = Settings(
         tmdb_api_key=api_key,
+        rewrite_root_dirs=[tmp_path],
+        preferred_languages=["zh-CN"],
+        service_mode="rollback",
+    )
+
+    assert settings.tmdb_api_key == ""
+
+
+def test_rollback_mode_allows_missing_tmdb_api_key(tmp_path: Path) -> None:
+    """Rollback mode allows the TMDB API key to be omitted."""
+    settings = Settings(
         rewrite_root_dirs=[tmp_path],
         preferred_languages=["zh-CN"],
         service_mode="rollback",

--- a/tests/unit/test_tmdb_api_key_validation.py
+++ b/tests/unit/test_tmdb_api_key_validation.py
@@ -48,6 +48,33 @@ def test_rewrite_mode_rejects_missing_tmdb_api_key(
         )
 
 
+def test_rollback_mode_normalizes_none_tmdb_api_key(tmp_path: Path) -> None:
+    """Rollback mode treats a None TMDB API key as empty."""
+    settings = Settings.model_validate(
+        {
+            "tmdb_api_key": None,
+            "rewrite_root_dirs": [tmp_path],
+            "preferred_languages": ["zh-CN"],
+            "service_mode": "rollback",
+        }
+    )
+
+    assert settings.tmdb_api_key == ""
+
+
+def test_rewrite_mode_rejects_non_string_tmdb_api_key(tmp_path: Path) -> None:
+    """TMDB API keys must be strings."""
+    with pytest.raises(ValidationError, match="tmdb_api_key must be a string"):
+        Settings.model_validate(
+            {
+                "tmdb_api_key": 123,
+                "rewrite_root_dirs": [tmp_path],
+                "preferred_languages": ["zh-CN"],
+                "service_mode": "rewrite",
+            }
+        )
+
+
 @pytest.mark.parametrize("api_key", ["", " ", "\t"])
 def test_rollback_mode_allows_empty_tmdb_api_key(
     api_key: str,

--- a/tests/unit/test_tmdb_api_key_validation.py
+++ b/tests/unit/test_tmdb_api_key_validation.py
@@ -1,0 +1,92 @@
+"""Tests for service-mode-dependent TMDB API key validation."""
+
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+from pydantic import ValidationError
+
+from sonarr_metadata_rewrite.config import Settings, get_settings
+from sonarr_metadata_rewrite.main import cli
+
+
+@pytest.mark.parametrize("api_key", ["", " ", "\t", "\n"])
+def test_rewrite_mode_rejects_empty_tmdb_api_key(
+    api_key: str,
+    tmp_path: Path,
+) -> None:
+    """Rewrite mode requires a non-empty TMDB API key."""
+    with pytest.raises(
+        ValidationError,
+        match="TMDB_API_KEY is required when SERVICE_MODE=rewrite",
+    ):
+        Settings(
+            tmdb_api_key=api_key,
+            rewrite_root_dirs=[tmp_path],
+            preferred_languages=["zh-CN"],
+            service_mode="rewrite",
+        )
+
+
+@pytest.mark.parametrize("api_key", [None, "", " ", "\t"])
+def test_rollback_mode_allows_missing_tmdb_api_key(
+    api_key: str | None,
+    tmp_path: Path,
+) -> None:
+    """Rollback mode does not access TMDB and must not require its API key."""
+    settings = Settings(
+        tmdb_api_key=api_key,
+        rewrite_root_dirs=[tmp_path],
+        preferred_languages=["zh-CN"],
+        service_mode="rollback",
+    )
+
+    assert settings.tmdb_api_key == ""
+
+
+def test_get_settings_rejects_empty_tmdb_api_key_in_rewrite_mode(
+    tmp_path: Path,
+) -> None:
+    """Environment loading reports a configuration error before HTTP setup."""
+    env_vars = {
+        "TMDB_API_KEY": " ",
+        "REWRITE_ROOT_DIR": str(tmp_path),
+        "PREFERRED_LANGUAGES": "zh-CN",
+        "SERVICE_MODE": "rewrite",
+    }
+
+    with (
+        patch.dict(os.environ, env_vars, clear=True),
+        pytest.raises(
+            ValueError,
+            match="TMDB_API_KEY is required when SERVICE_MODE=rewrite",
+        ),
+    ):
+        get_settings()
+
+
+def test_cli_rollback_mode_runs_without_tmdb_api_key(tmp_path: Path) -> None:
+    """Rollback CLI starts without logging or requiring a TMDB API key."""
+    runner = CliRunner()
+    env_vars = {
+        "REWRITE_ROOT_DIR": str(tmp_path),
+        "PREFERRED_LANGUAGES": "zh-CN",
+        "SERVICE_MODE": "rollback",
+    }
+
+    with (
+        patch.dict(os.environ, env_vars, clear=True),
+        patch("sonarr_metadata_rewrite.main.RollbackService") as rollback_service,
+    ):
+        rollback_service.return_value.execute_rollback.return_value = None
+        rollback_service.return_value.hang_after_completion.side_effect = (
+            KeyboardInterrupt()
+        )
+        result = runner.invoke(cli)
+
+    assert result.exit_code == 0
+    assert "🔧 Service mode: rollback" in result.output
+    assert "🔄 Executing rollback operation..." in result.output
+    assert "TMDB API key loaded" not in result.output

--- a/vulture_whitelist.py
+++ b/vulture_whitelist.py
@@ -5,8 +5,10 @@
 _.model_config
 
 # Pydantic validators are used by the framework
+_.normalize_tmdb_api_key
 _.parse_preferred_languages
 _.parse_rewrite_root_dirs
+_.validate_mode_requirements
 _.validate_service_mode
 _.cls
 


### PR DESCRIPTION
## Summary

Validate `TMDB_API_KEY` while loading configuration instead of allowing an empty value to reach TMDB HTTP setup.

- Normalize missing, empty, and whitespace-only keys to an empty value.
- In rewrite mode, fail immediately with a clear configuration error when the key is empty.
- In rollback mode, allow no key because rollback restores local backups without using TMDB.
- Print TMDB key status only when a key is configured.

## Why

An empty TMDB API key previously reached the HTTP client and resulted in an invalid `Authorization: Bearer ` header. Reporting the error during startup makes the configuration problem explicit before any TMDB request is attempted.

## Impact

Rewrite mode exits early for a missing, empty, or whitespace-only key. Rollback remains usable without a TMDB key.