### PR TITLE
fix: handle UTF-8 BOM when parsing NFO files

### DIFF
--- a/src/sonarr_metadata_rewrite/file_utils.py
+++ b/src/sonarr_metadata_rewrite/file_utils.py
@@ -179,7 +179,7 @@ def extract_metadata_info(nfo_path: Path) -> MetadataInfo:
 
 def _parse_nfo_documents(nfo_path: Path) -> MetadataInfo:
     """Parse one or more adjacent XML documents from an NFO file."""
-    raw_content = nfo_path.read_bytes().decode("utf-8")
+    raw_content = nfo_path.read_bytes().decode("utf-8").replace("\ufeff", "")
     xml_content, scraper_urls = _split_trailing_scraper_urls(raw_content)
     normalized_content = xml_content.strip()
     normalized_content = re.sub(r"<\?xml[^>]*\?>", "", normalized_content).strip()

--- a/tests/unit/test_file_utils.py
+++ b/tests/unit/test_file_utils.py
@@ -499,6 +499,20 @@ class TestExtractMetadataInfo:
 
         parse_documents.assert_called_once_with(nfo_path)
 
+    def test_extract_metadata_info_handles_utf8_bom(self, test_data_dir: Path) -> None:
+        """Parse NFO content that starts with a UTF-8 BOM."""
+        nfo_path = test_data_dir / "bom.nfo"
+        nfo_path.write_bytes(
+            b"\xef\xbb\xbf"
+            b'<?xml version="1.0" encoding="utf-8"?>\n'
+            b"<tvshow>\n  <title>Breaking Bad</title>\n</tvshow>\n"
+        )
+
+        info = extract_metadata_info(nfo_path)
+
+        assert info.file_type == "tvshow"
+        assert info.title == "Breaking Bad"
+
 
 class TestFindRootDirForFile:
     """Tests for find_root_dir_for_file."""


### PR DESCRIPTION
Fixes #110

## Cause
NFO files produced by Kodi/Sonarr can start with a UTF-8 byte order mark (`EF BB BF`). When reading the file with `read_bytes().decode("utf-8")`, the BOM survives as `\ufeff`, which Python does not treat as whitespace. It therefore lands in `wrapped_root.text` inside `<nfo-root>`, triggering the strict `Invalid text outside NFO XML document` guard in `_parse_nfo_documents` and crashing processing with a `ET.ParseError` instead of skipping the file gracefully.

## Resolution
Strip the BOM (`\ufeff`) from the decoded content before wrapping and parsing. NFO files with a leading BOM now parse normally; e.g. a Kodi `season.nfo` with a `<season>` root now reaches the existing `UnsupportedNfoRootError` path and is skipped cleanly instead of erroring.

Added a regression test (`test_extract_metadata_info_handles_utf8_bom`) covering a BOM-prefixed NFO.
