### PR TITLE
feat: request PNG from TMDB instead of SVG

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -138,8 +138,8 @@ rewrite with embedded marker, and atomic writes with optional backup.
 
 1. **ImageUtils** (`image_utils.py`)
 Image metadata helpers for embedding and reading markers in PNG (tEXt chunk) and
-JPEG (EXIF UserComment) formats. Markers contain TMDB file_path and language info
-to enable reprocessing avoidance.
+JPEG (EXIF UserComment) formats. Markers contain TMDB file_path and language
+info to enable reprocessing avoidance.
 
 1. **RollbackService** (`rollback_service.py`)
 Backup restoration service that reverts .nfo and image files to their original
@@ -177,6 +177,9 @@ development fallback.
   `/tv/{series_id}/season/{season_number}/images`, and `/movie/{movie_id}/images`
   - Don't pass `include_image_language`; fetch all and filter client-side in
     code due to TMDB API quirk
+  - TMDB clearlogos are often `.svg`; request TMDB's `.png` variant (preserving
+    transparency) before embedding markers, while retaining the `.svg` path in
+    the marker
 - **Rate Limits**: TMDB has rate limits, and explicit rate limiting with
   exponential backoff retry is implemented to handle HTTP 429 responses
 - **Language Codes**: ISO 639-1 format with optional country codes (e.g.,
@@ -238,7 +241,8 @@ scripts/ (development automation)
   in PNG tEXt or JPEG EXIF UserComment; if marker matches current selection,
   skip writing
 - Atomic writes: write to temp file and replace; normalize extension according
-  to TMDB candidate while preserving original stem
+  to TMDB candidate while preserving original stem (TMDB `.svg` candidates use
+  TMDB's `.png` variant to keep transparency)
 - Backups: if `ORIGINAL_FILES_BACKUP_DIR` is set, copy original before rewrite
 - Rollback: restores both `.nfo` and image files; removes conflicting ext variants
 

--- a/src/sonarr_metadata_rewrite/image_processor.py
+++ b/src/sonarr_metadata_rewrite/image_processor.py
@@ -246,8 +246,20 @@ class ImageProcessor:
             dst_path: Destination path for image
             candidate: ImageCandidate with file_path and language info
         """
-        # Build full URL
-        url = f"{TMDB_IMAGE_BASE_URL}{candidate.file_path}"
+        candidate_ext = Path(candidate.file_path).suffix.lower()
+        download_path = candidate.file_path
+        if candidate_ext == ".svg":
+            # TMDB serves SVG logos as PNG when requested with this extension.
+            download_path = f"{candidate.file_path[: -len(candidate_ext)]}.png"
+            candidate_ext = ".png"
+        elif candidate_ext not in IMAGE_EXTENSIONS:
+            raise ValueError(
+                f"Unsupported image format from TMDB: {candidate_ext}. "
+                f"Supported formats: {', '.join(sorted(IMAGE_EXTENSIONS))}, .svg"
+            )
+
+        # Keep the original SVG candidate path in the marker, but download its PNG.
+        url = f"{TMDB_IMAGE_BASE_URL}{download_path}"
 
         # Download with retry
         @retry(timeout=30.0, interval=1.0, exceptions=(httpx.HTTPError,))
@@ -260,15 +272,6 @@ class ImageProcessor:
 
         # Build marker
         marker = candidate
-
-        # Compute destination path with correct extension
-        # Extract extension from candidate.file_path
-        candidate_ext = Path(candidate.file_path).suffix.lower()
-        if candidate_ext not in IMAGE_EXTENSIONS:
-            raise ValueError(
-                f"Unsupported image format from TMDB: {candidate_ext}. "
-                f"Supported formats: {', '.join(sorted(IMAGE_EXTENSIONS))}"
-            )
 
         # Use original filename stem with TMDB extension
         original_stem = dst_path.stem

--- a/tests/unit/test_image_processor.py
+++ b/tests/unit/test_image_processor.py
@@ -956,6 +956,39 @@ class TestAdditionalCoverageScenarios:
         assert result.success is False
         assert "Unsupported image format" in result.message
 
+    def test_process_svg_candidate_downloads_png_variant(
+        self, tmp_path: Path, image_processor: ImageProcessor
+    ) -> None:
+        """Test SVG candidates use TMDB's transparent PNG variant."""
+        series_dir = tmp_path / "Series"
+        series_dir.mkdir()
+        clearlogo_path = series_dir / "clearlogo.png"
+
+        create_test_image(clearlogo_path)
+
+        candidate = ImageCandidate(
+            file_path="/test_logo.svg", iso_639_1="en", iso_3166_1="US"
+        )
+        image_processor.translator.select_best_image = Mock(return_value=candidate)  # type: ignore[method-assign]
+
+        png = Image.new("RGBA", (120, 120), color=(255, 0, 0, 128))
+        output = BytesIO()
+        png.save(output, format="PNG")
+        mock_response = Mock(content=output.getvalue())
+        image_processor.http_client.get = Mock(return_value=mock_response)  # type: ignore[method-assign]
+
+        image_processor._download_and_write_image(clearlogo_path, candidate)
+
+        image_processor.http_client.get.assert_called_once_with(
+            "https://image.tmdb.org/t/p/original/test_logo.png"
+        )
+        assert clearlogo_path.exists()
+        with Image.open(clearlogo_path) as img:
+            assert img.format == "PNG"
+            assert img.mode == "RGBA"
+            assert img.getchannel("A").getextrema()[1] > 0
+        assert read_embedded_marker(clearlogo_path) == candidate
+
     def test_close_http_client(self, image_processor: ImageProcessor) -> None:
         """Test closing HTTP client."""
         image_processor.close()

--- a/tests/unit/test_image_processor.py
+++ b/tests/unit/test_image_processor.py
@@ -986,7 +986,7 @@ class TestAdditionalCoverageScenarios:
         with Image.open(clearlogo_path) as img:
             assert img.format == "PNG"
             assert img.mode == "RGBA"
-            assert img.getchannel("A").getextrema()[1] > 0
+            assert img.getpixel((0, 0)) == (255, 0, 0, 128)
         assert read_embedded_marker(clearlogo_path) == candidate
 
     def test_close_http_client(self, image_processor: ImageProcessor) -> None:


### PR DESCRIPTION
## Summary

TMDB clearlogos are frequently returned as `.svg` candidates, while the image pipeline only accepts raster formats. Previously, a clearlogo such as `/kXbYq6p1SQnXT7BhB5ytzvqW6iV.svg` would download successfully but then fail with `Unsupported image format from TMDB: .svg`.

TMDB supports requesting an SVG asset as PNG by changing its URL extension. This PR uses that PNG download path while preserving TMDB's original SVG `file_path` in the embedded marker, so reprocessing avoidance continues to match the candidate returned by the API.

## Changes

- **image_processor.py**: for `.svg` candidates, request TMDB's corresponding `.png` URL before downloading; write the result as `*.png` with the original filename stem (for example, `clearlogo.png`).
- **tests**: verify the PNG download URL, PNG output, embedded original SVG marker, and non-zero alpha.
- **AGENTS.md**: document the direct TMDB PNG variant behavior.

## Notes

- The original `.svg` `file_path` remains in the marker, matching the candidate returned by `select_best_image()` and preventing unnecessary repeat downloads.
- Other unsupported image formats still produce the existing error.