### PR TITLE
fix: normalize CR/CRLF in TMDB translations to prevent rewrite loops

### DIFF
--- a/src/sonarr_metadata_rewrite/translator.py
+++ b/src/sonarr_metadata_rewrite/translator.py
@@ -16,6 +16,15 @@ from sonarr_metadata_rewrite.models import (
 )
 
 
+def _normalize_line_endings(value: str) -> str:
+    """Normalize CRLF and lone CR to LF.
+
+    TMDB content can contain carriage returns; XML parsing normalizes CR to LF,
+    so without this the written file would never match the in-memory translation.
+    """
+    return value.replace("\r\n", "\n").replace("\r", "\n")
+
+
 class Translator:
     """TMDB API client with caching and rate limiting."""
 
@@ -153,9 +162,11 @@ class Translator:
             )
 
             title_key = "title" if media_type == "movie" else "name"
-            title = str(data.get(title_key) or "").strip()
-            description = str(data.get("overview") or "").strip()
-            tagline = str(data.get("tagline") or "").strip()
+            title = _normalize_line_endings(str(data.get(title_key) or "").strip())
+            description = _normalize_line_endings(
+                str(data.get("overview") or "").strip()
+            )
+            tagline = _normalize_line_endings(str(data.get("tagline") or "").strip())
 
             translations[full_language_code] = TranslatedContent(
                 title=TranslatedString(

--- a/tests/unit/test_translator.py
+++ b/tests/unit/test_translator.py
@@ -273,6 +273,39 @@ def test_get_translations_keeps_tagline_only_record(translator: Translator) -> N
     assert translations["zh-CN"].tagline.content == "命运由你掌握。"
 
 
+def test_parse_api_translations_normalizes_carriage_returns(
+    translator: Translator,
+) -> None:
+    """Test that CR and CRLF in TMDB content are normalized to LF.
+
+    Without this, a written .nfo would contain normalized LF after XML round-trip
+    while the in-memory translation kept CR, triggering endless rewrites.
+    """
+    translations = translator._parse_api_translations(
+        {
+            "translations": [
+                {
+                    "iso_639_1": "de",
+                    "iso_3166_1": "DE",
+                    "data": {
+                        "name": "Sachen.\r Wendy",
+                        "overview": "Zeile eins.\r\nZeile zwei.\rZeile drei.",
+                        "tagline": "Ein\rTag.",
+                    },
+                }
+            ]
+        },
+        "tv",
+    )
+
+    assert translations["de-DE"].title.content == "Sachen.\n Wendy"
+    assert (
+        translations["de-DE"].description.content
+        == "Zeile eins.\nZeile zwei.\nZeile drei."
+    )
+    assert translations["de-DE"].tagline.content == "Ein\nTag."
+
+
 @patch("httpx.Client.get")
 def test_get_translations_http_error(mock_get: Mock, translator: Translator) -> None:
     """Test HTTP error handling."""


### PR DESCRIPTION
Fixes an infinite rewrite loop: TMDB overview/tagline content can contain literal carriage returns (\\r\). The in-memory translation kept the \\r\, but after writing the .nfo and re-reading it via ElementTree, XML parsing normalizes CR to LF, so the on-disk description never matched the in-memory one and the file was rewritten on every scan.

Normalizes CRLF and lone CR to LF at the parse choke point (\_parse_api_translations\), covering title, overview, and tagline for TV, episode, and movie translations.

Existing looped files self-heal on the next scan since the comparison now passes without rewriting.