### PR TITLE
fix(metadata): clarify unchanged translation messages

### DIFF
--- a/src/sonarr_metadata_rewrite/metadata_processor.py
+++ b/src/sonarr_metadata_rewrite/metadata_processor.py
@@ -792,17 +792,9 @@ class MetadataProcessor:
         Returns:
             Formatted success message
         """
-        if (
-            translation.title.content
-            and translation.description.content
-            and translation.title.source == "translation"
-            and translation.title.source_tag == translation.description.source_tag
-            and (
-                not translation.tagline.content
-                or translation.tagline.source_tag == translation.title.source_tag
-            )
-        ):
-            return f"Successfully translated to {translation.title.source_tag}"
+        translation_tag = self._get_single_translation_language(translation)
+        if translation_tag is not None:
+            return f"Successfully translated to {translation_tag}"
 
         fields = (
             ("title", translation.title),
@@ -816,6 +808,31 @@ class MetadataProcessor:
         ]
         return f"Successfully translated ({', '.join(parts)})"
 
+    def _get_single_translation_language(
+        self, translation: TranslatedContent
+    ) -> str | None:
+        """Return the language for a complete single-language translation."""
+        title = translation.title
+        description = translation.description
+        tagline = translation.tagline
+        if (
+            not title.content
+            or not description.content
+            or title.source != "translation"
+            or description.source != "translation"
+            or title.source_tag is None
+            or title.source_tag != description.source_tag
+            or (
+                tagline.content
+                and (
+                    tagline.source != "translation"
+                    or tagline.source_tag != title.source_tag
+                )
+            )
+        ):
+            return None
+        return title.source_tag
+
     def _build_unchanged_message(self, translation: TranslatedContent) -> str:
         """Build an unchanged result with selected content provenance."""
         fields = (
@@ -824,15 +841,11 @@ class MetadataProcessor:
             ("tagline", translation.tagline),
         )
         selected_fields = [(name, value) for name, value in fields if value.content]
-        translation_tag = selected_fields[0][1].source_tag if selected_fields else None
+        translation_tag = self._get_single_translation_language(translation)
         all_selected_fields_are_translations = bool(selected_fields) and all(
             value.source == "translation" for _, value in selected_fields
         )
-        if (
-            all_selected_fields_are_translations
-            and translation_tag is not None
-            and all(value.source_tag == translation_tag for _, value in selected_fields)
-        ):
+        if translation_tag is not None:
             return f"Content already matches {translation_tag} translation"
 
         parts = [

--- a/src/sonarr_metadata_rewrite/metadata_processor.py
+++ b/src/sonarr_metadata_rewrite/metadata_processor.py
@@ -825,11 +825,11 @@ class MetadataProcessor:
         )
         selected_fields = [(name, value) for name, value in fields if value.content]
         translation_tag = selected_fields[0][1].source_tag if selected_fields else None
-        all_translation = bool(selected_fields) and all(
+        all_selected_fields_are_translations = bool(selected_fields) and all(
             value.source == "translation" for _, value in selected_fields
         )
         if (
-            all_translation
+            all_selected_fields_are_translations
             and translation_tag is not None
             and all(value.source_tag == translation_tag for _, value in selected_fields)
         ):
@@ -839,7 +839,9 @@ class MetadataProcessor:
             self._format_field_provenance(name, value)
             for name, value in selected_fields
         ]
-        selection_kind = "translation" if all_translation else "metadata"
+        selection_kind = (
+            "translation" if all_selected_fields_are_translations else "metadata"
+        )
         return f"Content already matches selected {selection_kind} ({', '.join(parts)})"
 
     def _format_field_provenance(self, name: str, value: TranslatedString) -> str:

--- a/src/sonarr_metadata_rewrite/metadata_processor.py
+++ b/src/sonarr_metadata_rewrite/metadata_processor.py
@@ -308,6 +308,7 @@ class MetadataProcessor:
                 unchanged_count=unchanged_count,
                 unavailable_count=unavailable_count,
                 episode_count=len(episode_entries),
+                unchanged_translation=selected_translation,
             )
             return MetadataProcessResult(
                 success=True,
@@ -816,11 +817,30 @@ class MetadataProcessor:
         return f"Successfully translated ({', '.join(parts)})"
 
     def _build_unchanged_message(self, translation: TranslatedContent) -> str:
-        """Build an unchanged result with Original Title fallback provenance."""
-        if translation.title.source != "original_title":
-            return "Content already matches preferred translation"
-        title = self._format_field_provenance("title", translation.title)
-        return f"Content already matches preferred translation ({title})"
+        """Build an unchanged result with selected content provenance."""
+        fields = (
+            ("title", translation.title),
+            ("description", translation.description),
+            ("tagline", translation.tagline),
+        )
+        selected_fields = [(name, value) for name, value in fields if value.content]
+        translation_tag = selected_fields[0][1].source_tag if selected_fields else None
+        all_translation = bool(selected_fields) and all(
+            value.source == "translation" for _, value in selected_fields
+        )
+        if (
+            all_translation
+            and translation_tag is not None
+            and all(value.source_tag == translation_tag for _, value in selected_fields)
+        ):
+            return f"Content already matches {translation_tag} translation"
+
+        parts = [
+            self._format_field_provenance(name, value)
+            for name, value in selected_fields
+        ]
+        selection_kind = "translation" if all_translation else "metadata"
+        return f"Content already matches selected {selection_kind} ({', '.join(parts)})"
 
     def _format_field_provenance(self, name: str, value: TranslatedString) -> str:
         """Format one selected field's provenance for a process result."""
@@ -870,11 +890,14 @@ class MetadataProcessor:
         unchanged_count: int,
         unavailable_count: int,
         episode_count: int,
+        unchanged_translation: TranslatedContent | None = None,
     ) -> str:
         """Build a status message for multi-episode files."""
         if episode_count == 1:
             if updated_count == 1:
                 return "Successfully translated 1 episode"
+            if unchanged_translation is not None:
+                return self._build_unchanged_message(unchanged_translation)
             return "Content already matches preferred translation"
 
         parts = [f"{updated_count} of {episode_count} episodes updated"]

--- a/tests/unit/test_metadata_processor.py
+++ b/tests/unit/test_metadata_processor.py
@@ -658,6 +658,37 @@ def test_build_success_message_mixed_languages(
     assert message == "Successfully translated (title: fr-CA, description: fr-FR)"
 
 
+def test_build_unchanged_message_single_language(
+    processor: MetadataProcessor,
+) -> None:
+    """Test unchanged content reports the language of a complete translation."""
+    translation = TranslatedContent(
+        title=TranslatedString(content="Titre français", language="fr-FR"),
+        description=TranslatedString(content="Description française", language="fr-FR"),
+    )
+
+    message = processor._build_unchanged_message(translation)
+
+    assert message == "Content already matches fr-FR translation"
+
+
+def test_build_unchanged_message_mixed_languages(
+    processor: MetadataProcessor,
+) -> None:
+    """Test unchanged content reports provenance for mixed translations."""
+    translation = TranslatedContent(
+        title=TranslatedString(content="Titre français", language="fr-FR"),
+        description=TranslatedString(content="English description", language="en-US"),
+    )
+
+    message = processor._build_unchanged_message(translation)
+
+    assert message == (
+        "Content already matches selected translation "
+        "(title: fr-FR, description: en-US)"
+    )
+
+
 def test_build_success_message_reports_existing_nfo_content(
     processor: MetadataProcessor,
 ) -> None:
@@ -1104,7 +1135,7 @@ def test_content_matches_preferred_translation_skips_processing(
         expected_success=True,
         expected_file_modified=False,
         expected_language="zh-CN",
-        expected_message_contains="already matches preferred translation",
+        expected_message_contains="already matches zh-CN translation",
     )
 
 
@@ -1235,7 +1266,7 @@ def test_multiple_rapid_processing_only_first_modifies(
         result2,
         expected_success=True,
         expected_file_modified=False,
-        expected_message_contains="already matches preferred translation",
+        expected_message_contains="already matches zh-CN translation",
     )
 
     # Third processing - still should skip
@@ -1707,7 +1738,7 @@ def test_content_matches_after_fallback_skips_processing(
         result,
         expected_success=True,
         expected_file_modified=False,  # Key test: should NOT modify file
-        expected_message_contains="already matches preferred translation",
+        expected_message_contains="already matches selected metadata",
     )
 
     # Verify the translated content reflects the fallback result
@@ -1718,6 +1749,42 @@ def test_content_matches_after_fallback_skips_processing(
     assert result.translated_content.title.source == "existing_nfo"
     assert result.translated_content.description.content == "这是一个示例描述"
     assert result.translated_content.description.source_tag == "zh-CN"
+
+
+def test_single_episode_unchanged_message_uses_translation_provenance(
+    test_data_dir: Path,
+    create_test_files: Callable[[str, Path], Path],
+) -> None:
+    """Test a single unchanged episode reports its selected translation."""
+    settings = create_test_settings(test_data_dir, preferred_languages="fr-FR")
+    mock_translator = Mock(spec=Translator)
+    mock_translator.get_translations.return_value = {
+        "fr-FR": translated_content("Titre français", "Description française", "fr-FR")
+    }
+    processor = MetadataProcessor(settings, mock_translator)
+
+    nfo_path = create_test_files("episode.nfo", test_data_dir / "episode.nfo")
+    nfo_path.write_text(
+        nfo_path.read_text(encoding="utf-8")
+        .replace("Pilot", "Titre français")
+        .replace(
+            "Walter White, a struggling high school chemistry teacher, is diagnosed "
+            "with advanced lung cancer. He turns to a life of crime, producing and "
+            "selling methamphetamine with a former student, Jesse Pinkman, with the "
+            "goal of securing his family's financial future before he dies.",
+            "Description française",
+        ),
+        encoding="utf-8",
+    )
+
+    result = processor.process_file(nfo_path)
+
+    assert result.success is True
+    assert result.file_modified is False
+    assert result.message == "Content already matches fr-FR translation"
+    assert result.translated_content is not None
+    assert result.translated_content.title.source_tag == "fr-FR"
+    assert result.translated_content.description.source_tag == "fr-FR"
 
 
 def test_process_file_multi_episode_partial_update(

--- a/tests/unit/test_metadata_processor.py
+++ b/tests/unit/test_metadata_processor.py
@@ -672,6 +672,20 @@ def test_build_unchanged_message_single_language(
     assert message == "Content already matches fr-FR translation"
 
 
+def test_build_unchanged_message_incomplete_translation_uses_provenance(
+    processor: MetadataProcessor,
+) -> None:
+    """Test an incomplete translation uses detailed provenance."""
+    translation = TranslatedContent(
+        title=TranslatedString(content="Titre français", language="fr-FR"),
+        description=TranslatedString(content="", language="fr-FR"),
+    )
+
+    message = processor._build_unchanged_message(translation)
+
+    assert message == "Content already matches selected translation (title: fr-FR)"
+
+
 def test_build_unchanged_message_mixed_languages(
     processor: MetadataProcessor,
 ) -> None:

--- a/tests/unit/test_metadata_processor.py
+++ b/tests/unit/test_metadata_processor.py
@@ -703,6 +703,21 @@ def test_build_unchanged_message_mixed_languages(
     )
 
 
+def test_build_multi_episode_message_single_episode_without_translation(
+    processor: MetadataProcessor,
+) -> None:
+    """Test the generic unchanged message for a single episode."""
+    message = processor._build_multi_episode_message(
+        updated_count=0,
+        translated_count=0,
+        unchanged_count=0,
+        unavailable_count=0,
+        episode_count=1,
+    )
+
+    assert message == "Content already matches preferred translation"
+
+
 def test_build_success_message_reports_existing_nfo_content(
     processor: MetadataProcessor,
 ) -> None:

--- a/tests/unit/test_original_title_fallback.py
+++ b/tests/unit/test_original_title_fallback.py
@@ -80,11 +80,14 @@ def test_original_title_fallback_noop_message_includes_provenance(
                 source_tag="zh",
                 selection_tag="zh-CN",
             ),
-            description=TranslatedString(content=""),
+            description=TranslatedString(
+                content="中文简介", source="translation", source_tag="zh-CN"
+            ),
         )
     )
 
     assert message == (
-        "Content already matches preferred translation "
-        '(title: Original Title "捕风追影" [zh], fallback for zh-CN)'
+        "Content already matches selected metadata "
+        '(title: Original Title "捕风追影" [zh], fallback for zh-CN, '
+        "description: zh-CN)"
     )


### PR DESCRIPTION
Improve unchanged metadata messages by reporting the matching translation language or per-field provenance for mixed and fallback selections. Single-episode unchanged files now use the same provenance-aware formatting without changing translation selection or fallback behavior.