### PR TITLE
fix: normalize BOM in TMDB translations

### DIFF
--- a/src/sonarr_metadata_rewrite/translator.py
+++ b/src/sonarr_metadata_rewrite/translator.py
@@ -18,12 +18,12 @@ from sonarr_metadata_rewrite.models import (
 
 
 def _normalize_line_endings(value: str) -> str:
-    """Normalize CRLF and lone CR to LF.
+    """Normalize line endings and remove BOM characters.
 
-    TMDB content can contain carriage returns; XML parsing normalizes CR to LF,
-    so without this the written file would never match the in-memory translation.
+    XML parsing normalizes carriage returns and removes BOM characters, so TMDB
+    content needs the same normalization to avoid repeat rewrites.
     """
-    return value.replace("\r\n", "\n").replace("\r", "\n")
+    return value.replace("\ufeff", "").replace("\r\n", "\n").replace("\r", "\n")
 
 
 def _calculate_translation_cache_ttl(

--- a/tests/unit/test_translator.py
+++ b/tests/unit/test_translator.py
@@ -279,13 +279,13 @@ def test_get_translations_keeps_tagline_only_record(translator: Translator) -> N
     assert translations["zh-CN"].tagline.content == "命运由你掌握。"
 
 
-def test_parse_api_translations_normalizes_carriage_returns(
+def test_parse_api_translations_normalizes_xml_characters(
     translator: Translator,
 ) -> None:
-    """Test that CR and CRLF in TMDB content are normalized to LF.
+    """Test that TMDB content is normalized consistently with XML parsing.
 
-    Without this, a written .nfo would contain normalized LF after XML round-trip
-    while the in-memory translation kept CR, triggering endless rewrites.
+    Without this, a written .nfo can differ from the in-memory translation after
+    XML round-trip, triggering endless rewrites.
     """
     translations = translator._parse_api_translations(
         {
@@ -294,9 +294,9 @@ def test_parse_api_translations_normalizes_carriage_returns(
                     "iso_639_1": "de",
                     "iso_3166_1": "DE",
                     "data": {
-                        "name": "Sachen.\r Wendy",
-                        "overview": "Zeile eins.\r\nZeile zwei.\rZeile drei.",
-                        "tagline": "Ein\rTag.",
+                        "name": "Sachen.\ufeff\r Wendy",
+                        "overview": "Zeile eins.\r\nZeile zwei.\ufeff\rZeile drei.",
+                        "tagline": "Ein\ufeff\rTag.",
                     },
                 }
             ]


### PR DESCRIPTION
Normalizes embedded BOM characters in TMDB translation fields and adds regression coverage.

Root cause: TMDB returned the German Squid Game S02E06 title with an embedded U+FEFF. The NFO parser removed it, but the translator wrote it back on every monitored replacement.

Validated with focused unit tests, Ruff, and a live Unraid-container check showing file_modified=False for the affected NFO.